### PR TITLE
Incorrect scaling for `t` calculation in HyperdriveMath

### DIFF
--- a/contracts/libraries/HyperdriveMath.sol
+++ b/contracts/libraries/HyperdriveMath.sol
@@ -34,10 +34,7 @@ library HyperdriveMath {
         uint256 _positionDuration,
         uint256 _timeStretch
     ) internal pure returns (uint256 apr) {
-
-        // NOTE: The calculation here is automatically scaled in the divDown
-        // operation and presumes _positionDuration input as described in the
-        // Hyperdrive constructor.
+        // NOTE: This calculation is automatically scaled in the divDown operation
         uint256 t = _positionDuration.divDown(365 days);
         uint256 tau = t.divDown(_timeStretch);
         // ((y + s) / (mu * z)) ** -tau
@@ -71,10 +68,7 @@ library HyperdriveMath {
         uint256 _positionDuration,
         uint256 _timeStretch
     ) internal pure returns (uint256 bondReserves) {
-
-        // NOTE: The calculation here is automatically scaled in the divDown
-        // operation and presumes _positionDuration input as described in the
-        // Hyperdrive constructor.
+        // NOTE: This calculation is automatically scaled in the divDown operation
         uint256 t = _positionDuration.divDown(365 days);
         uint256 tau = t.divDown(_timeStretch);
         // (1 + apr * t) ** (1 / tau)


### PR DESCRIPTION
Before this change calling `hyperdrive.initialize(...)` with a pool of `positionDuration = X days` caused a zero division error in the `interestFactor` calculation of `HyperdriveMath.calculateBondReserves(...)` due to `tau = 0`.

I did not verify but a similar calculation also exists in `HyperdriveMath.calculateAPRFromReserves(...)`