### PR TITLE
Fixed oversight in the calculation of time remaining

### DIFF
--- a/contracts/Hyperdrive.sol
+++ b/contracts/Hyperdrive.sol
@@ -303,7 +303,7 @@ contract Hyperdrive is MultiToken {
 
         // Calculate the pool and user deltas using the trading function.
         uint256 timeRemaining = block.timestamp < maturityTime
-            ? (maturityTime - block.timestamp) * FixedPointMath.ONE_18
+            ? (maturityTime - block.timestamp).divDown(positionDuration) // use divDown to scale to fixed point
             : 0;
         (
             uint256 poolShareDelta,
@@ -423,7 +423,7 @@ contract Hyperdrive is MultiToken {
 
         // Calculate the pool and user deltas using the trading function.
         uint256 timeRemaining = block.timestamp < maturityTime
-            ? (maturityTime - block.timestamp) * FixedPointMath.ONE_18
+            ? (maturityTime - block.timestamp).divDown(positionDuration) // use divDown to scale to fixed point
             : 0;
         (
             uint256 poolShareDelta,


### PR DESCRIPTION
Previously we were passing the time in seconds into `HyperdriveMath` for `timeRemaining`, but the input should really be a normalized value in the range of 0 and 1.

Some things for reviewers to be mindful of is that the YieldSpaceMath library says that the `t` parameter should be provided in terms of seconds until maturity. After reading the math, I think that the use proposed in this PR will work; however, it's good to double check.