### PR TITLE
Test the zero amount case for addLiquidity

### DIFF
--- a/test/Hyperdrive.t.sol
+++ b/test/Hyperdrive.t.sol
@@ -111,6 +111,22 @@ contract HyperdriveTest is Test {
         );
     }
 
+    /// addLiquidity ///
+
+    function test_addLiquidity_failure_ZeroAmount() external {
+        uint256 apr = 0.05e18;
+
+        // Initialize the pool with a large amount of capital.
+        uint256 contribution = 500_000_000e18;
+        initialize(alice, apr, contribution);
+
+        // Attempt to purchase bonds with zero base. This should fail.
+        vm.stopPrank();
+        vm.startPrank(bob);
+        vm.expectRevert(Errors.ZeroAmount.selector);
+        hyperdrive.addLiquidity(0, 0);
+    }
+
     /// openLong ///
 
     function test_open_long_zero_amount() external {


### PR DESCRIPTION
A one-off test that ensures that `addLiquidity` will fail if called with a zero amount.