### PR TITLE
Add kill_cache=1 query string param

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Tests](https://github.com/element-fi/hyperdrive/actions/workflows/test.yml/badge.svg)](https://github.com/element-fi/hyperdrive/actions/workflows/test.yml)
-[![Coverage](https://coveralls.io/repos/github/element-fi/hyperdrive/badge.svg?branch=main&t=US78Aq)](https://coveralls.io/github/element-fi/hyperdrive?branch=main)
+[![Coverage](https://coveralls.io/repos/github/element-fi/hyperdrive/badge.svg?branch=main&t=US78Aq&kill_cache=1)](https://coveralls.io/github/element-fi/hyperdrive?branch=main)
 
 # Hyperdrive
 


### PR DESCRIPTION
This PR fixes the issue with the coveralls badge not showing the latest coverage numbers.

Without fix:
[![Coverage Status](https://coveralls.io/repos/github/element-fi/hyperdrive/badge.svg?branch=main&t=US78Aq)](https://coveralls.io/github/element-fi/hyperdrive?branch=main)

With fix:
[![Coverage Status](https://coveralls.io/repos/github/element-fi/hyperdrive/badge.svg?branch=main&t=US78Aq&kill_cache=1)](https://coveralls.io/github/element-fi/hyperdrive?branch=main)