### PR TITLE
Encapsulate the open long assertions

### DIFF
--- a/test/units/hyperdrive/OpenLongTest.t.sol
+++ b/test/units/hyperdrive/OpenLongTest.t.sol
@@ -51,61 +51,19 @@ contract OpenLongTest is HyperdriveTest {
         // Get the reserves before opening the long.
         PoolInfo memory poolInfoBefore = getPoolInfo();
 
-        // Purchase a small amount of bonds.
+        // Open a long.
         uint256 baseAmount = 10e18;
         (uint256 maturityTime, uint256 bondAmount) = openLong(bob, baseAmount);
-        uint256 checkpointTime = maturityTime - POSITION_DURATION;
 
-        // Verify the base transfers.
-        assertEq(baseToken.balanceOf(bob), 0);
-        assertEq(
-            baseToken.balanceOf(address(hyperdrive)),
-            contribution + baseAmount
-        );
-
-        // Verify that opening a long doesn't make the APR go up.
-        uint256 realizedApr = calculateAPRFromRealizedPrice(
+        // Verify that the open long updated the state correctly.
+        verifyOpenLong(
+            poolInfoBefore,
+            contribution,
             baseAmount,
             bondAmount,
-            maturityTime - block.timestamp,
-            POSITION_DURATION
-        );
-        assertGt(apr, realizedApr);
-
-        // Verify that the reserves were updated correctly.
-        PoolInfo memory poolInfoAfter = getPoolInfo();
-        assertEq(
-            poolInfoAfter.shareReserves,
-            poolInfoBefore.shareReserves +
-                baseAmount.divDown(poolInfoBefore.sharePrice)
-        );
-        assertEq(
-            poolInfoAfter.bondReserves,
-            poolInfoBefore.bondReserves - bondAmount
-        );
-        assertEq(poolInfoAfter.lpTotalSupply, poolInfoBefore.lpTotalSupply);
-        assertEq(poolInfoAfter.sharePrice, poolInfoBefore.sharePrice);
-        assertEq(
-            poolInfoAfter.longsOutstanding,
-            poolInfoBefore.longsOutstanding + bondAmount
-        );
-        assertApproxEqAbs(
-            poolInfoAfter.longAverageMaturityTime,
             maturityTime,
-            1
+            apr
         );
-        assertEq(poolInfoAfter.longBaseVolume, baseAmount);
-        assertEq(
-            hyperdrive.longBaseVolumeCheckpoints(checkpointTime),
-            baseAmount
-        );
-        assertEq(
-            poolInfoAfter.shortsOutstanding,
-            poolInfoBefore.shortsOutstanding
-        );
-        assertEq(poolInfoAfter.shortAverageMaturityTime, 0);
-        assertEq(poolInfoAfter.shortBaseVolume, 0);
-        assertEq(hyperdrive.shortBaseVolumeCheckpoints(checkpointTime), 0);
     }
 
     function test_open_long_with_small_amount() external {
@@ -121,6 +79,26 @@ contract OpenLongTest is HyperdriveTest {
         // Purchase a small amount of bonds.
         uint256 baseAmount = .01e18;
         (uint256 maturityTime, uint256 bondAmount) = openLong(bob, baseAmount);
+
+        // Verify that the open long updated the state correctly.
+        verifyOpenLong(
+            poolInfoBefore,
+            contribution,
+            baseAmount,
+            bondAmount,
+            maturityTime,
+            apr
+        );
+    }
+
+    function verifyOpenLong(
+        PoolInfo memory poolInfoBefore,
+        uint256 contribution,
+        uint256 baseAmount,
+        uint256 bondAmount,
+        uint256 maturityTime,
+        uint256 apr
+    ) internal {
         uint256 checkpointTime = maturityTime - POSITION_DURATION;
 
         // Verify the base transfers.
@@ -134,7 +112,7 @@ contract OpenLongTest is HyperdriveTest {
         uint256 realizedApr = calculateAPRFromRealizedPrice(
             baseAmount,
             bondAmount,
-            maturityTime - block.timestamp,
+            FixedPointMath.ONE_18,
             POSITION_DURATION
         );
         assertGt(apr, realizedApr);


### PR DESCRIPTION
This PR encapsulates the assertions in "OpenLong.t.sol" to reduce code duplication.