### PR TITLE
Fix the coveralls badge being cached

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![Tests](https://github.com/element-fi/hyperdrive/actions/workflows/test.yml/badge.svg)](https://github.com/element-fi/hyperdrive/actions/workflows/test.yml)
-[![Coverage](https://coveralls.io/repos/github/element-fi/hyperdrive/badge.svg?branch=main&t=US78Aq&kill_cache=1)](https://coveralls.io/github/element-fi/hyperdrive?branch=main)
+[![Coverage](https://coveralls.io/repos/github/element-fi/hyperdrive/badge.svg?branch=main&t=US78Aq&kill_cache=1&service=github)](https://coveralls.io/github/element-fi/hyperdrive?branch=main)
 
 # Hyperdrive
 


### PR DESCRIPTION
Despite the kill-cache query parameter, the badge still doesn't update on main. Referring to [this issue](https://github.com/lemurheavy/coveralls-public/issues/971#issuecomment-693623226), it seems that adding `&service=github` will fix the issue. Anecdotally, it fixed the issue as I'm now seeing that we have 66% coverage.