### PR TITLE
Remove the virtual updates from flat+curve

### DIFF
--- a/contracts/libraries/HyperdriveMath.sol
+++ b/contracts/libraries/HyperdriveMath.sol
@@ -149,8 +149,6 @@ library HyperdriveMath {
         uint256 flat = _amountIn.mulDown(
             FixedPointMath.ONE_18.sub(_normalizedTimeRemaining)
         );
-        _shareReserves = _shareReserves.add(flat);
-        _bondReserves = _bondReserves.sub(flat.mulDown(_sharePrice));
         uint256 curveIn = _amountIn.mulDown(_normalizedTimeRemaining);
         // (time remaining)/(term length) is always 1 so we just use _timeStretch
         uint256 curveOut = YieldSpaceMath.calculateBondsOutGivenSharesIn(
@@ -197,17 +195,11 @@ library HyperdriveMath {
         // (our result is given in shares, so we divide the one-to-one
         // redemption by the share price) and the newly minted bonds are
         // traded on a YieldSpace curve configured to timeRemaining = 1.
-
-        // Calculate the flat part of the trade.
         uint256 flat = _amountIn
             .mulDown(FixedPointMath.ONE_18.sub(_normalizedTimeRemaining))
             .divDown(_sharePrice);
-
         if (_normalizedTimeRemaining > 0) {
-            // Calculate the curved part of the trade assuming that the flat part of
-            // the trade was applied to the share and bond reserves.
-            _shareReserves = _shareReserves.sub(flat);
-            _bondReserves = _bondReserves.add(flat.mulDown(_sharePrice));
+            // Calculate the curved part of the trade.
             uint256 curveIn = _amountIn.mulDown(_normalizedTimeRemaining);
             // (time remaining)/(term length) is always 1 so we just use _timeStretch
             uint256 curveOut = YieldSpaceMath.calculateSharesOutGivenBondsIn(
@@ -253,10 +245,7 @@ library HyperdriveMath {
         uint256 flat = _amountIn
             .mulDown(FixedPointMath.ONE_18.sub(_normalizedTimeRemaining))
             .divDown(_sharePrice);
-        // Calculate the curved part of the trade assuming that the flat part of
-        // the trade was applied to the share and bond reserves.
-        _shareReserves = _shareReserves.sub(flat);
-        _bondReserves = _bondReserves.add(flat.mulDown(_sharePrice));
+        // Calculate the curved part of the trade.
         uint256 curveIn = _amountIn.mulDown(_normalizedTimeRemaining).divDown(
             _sharePrice
         );
@@ -309,12 +298,9 @@ library HyperdriveMath {
         // the one-to-one redemption by the share price) and the newly
         // minted bonds are traded on a YieldSpace curve configured to
         // timeRemaining = 1.
-        // Calculate the flat part of the trade.
         uint256 flat = _amountOut
             .mulDown(FixedPointMath.ONE_18.sub(_normalizedTimeRemaining))
             .divDown(_sharePrice);
-        _shareReserves = _shareReserves.add(flat);
-        _bondReserves = _bondReserves.sub(flat.mulDown(_sharePrice));
         uint256 spotPrice = HyperdriveMath.calculateSpotPrice(
             _shareReserves,
             _bondReserves,
@@ -323,7 +309,6 @@ library HyperdriveMath {
             _normalizedTimeRemaining,
             _timeStretch
         );
-        // reuse variables to save stack space
         (_curveFee, _flatFee) = HyperdriveMath.calculateFeesInGivenOut(
             _amountOut, // amountOut
             _normalizedTimeRemaining,


### PR DESCRIPTION
Prior to this PR, flat+curve would virtually apply the flat part of the trade to the reserves prior to making the curve trade. This broke the natural symmetry between opening a position at the beginning of the checkpoint and closing the opposite position some part of the term later. For this reason, it's been removed. 