### PR TITLE
Ape compatibility

### DIFF
--- a/ape-config.yaml
+++ b/ape-config.yaml
@@ -1,0 +1,8 @@
+dependencies:
+  - name: OpenZeppelin
+    github: OpenZeppelin/openzeppelin-contracts
+    version: 4.8.1
+
+solidity:
+  import_remapping:
+    - "@openzeppelin/contracts=OpenZeppelin/4.8.1"

--- a/contracts/BondWrapper.sol
+++ b/contracts/BondWrapper.sol
@@ -5,7 +5,7 @@ import "./interfaces/IHyperdrive.sol";
 import "./interfaces/IERC20.sol";
 import "./libraries/ERC20Permit.sol";
 import "./libraries/Errors.sol";
-import "contracts/libraries/AssetId.sol";
+import "./libraries/AssetId.sol";
 
 contract BondWrapper is ERC20Permit {
     // The multitoken of the bond

--- a/contracts/Hyperdrive.sol
+++ b/contracts/Hyperdrive.sol
@@ -2,15 +2,15 @@
 pragma solidity ^0.8.18;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { HyperdriveBase } from "contracts/HyperdriveBase.sol";
-import { HyperdriveLong } from "contracts/HyperdriveLong.sol";
-import { HyperdriveLP } from "contracts/HyperdriveLP.sol";
-import { HyperdriveShort } from "contracts/HyperdriveShort.sol";
-import { AssetId } from "contracts/libraries/AssetId.sol";
-import { Errors } from "contracts/libraries/Errors.sol";
-import { FixedPointMath } from "contracts/libraries/FixedPointMath.sol";
-import { HyperdriveMath } from "contracts/libraries/HyperdriveMath.sol";
-import { IHyperdrive } from "contracts/interfaces/IHyperdrive.sol";
+import { HyperdriveBase } from "./HyperdriveBase.sol";
+import { HyperdriveLong } from "./HyperdriveLong.sol";
+import { HyperdriveLP } from "./HyperdriveLP.sol";
+import { HyperdriveShort } from "./HyperdriveShort.sol";
+import { AssetId } from "./libraries/AssetId.sol";
+import { Errors } from "./libraries/Errors.sol";
+import { FixedPointMath } from "./libraries/FixedPointMath.sol";
+import { HyperdriveMath } from "./libraries/HyperdriveMath.sol";
+import { IHyperdrive } from "./interfaces/IHyperdrive.sol";
 
 /// @author Delve
 /// @title Hyperdrive

--- a/contracts/HyperdriveBase.sol
+++ b/contracts/HyperdriveBase.sol
@@ -2,10 +2,10 @@
 pragma solidity ^0.8.18;
 
 import { IERC20 } from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
-import { MultiToken } from "contracts/MultiToken.sol";
-import { AssetId } from "contracts/libraries/AssetId.sol";
-import { Errors } from "contracts/libraries/Errors.sol";
-import { FixedPointMath } from "contracts/libraries/FixedPointMath.sol";
+import { MultiToken } from "./MultiToken.sol";
+import { AssetId } from "./libraries/AssetId.sol";
+import { Errors } from "./libraries/Errors.sol";
+import { FixedPointMath } from "./libraries/FixedPointMath.sol";
 
 /// @author Delve
 /// @title HyperdriveBase

--- a/contracts/HyperdriveLP.sol
+++ b/contracts/HyperdriveLP.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.18;
 
-import { HyperdriveBase } from "contracts/HyperdriveBase.sol";
-import { AssetId } from "contracts/libraries/AssetId.sol";
-import { Errors } from "contracts/libraries/Errors.sol";
-import { FixedPointMath } from "contracts/libraries/FixedPointMath.sol";
-import { HyperdriveMath } from "contracts/libraries/HyperdriveMath.sol";
+import { HyperdriveBase } from "./HyperdriveBase.sol";
+import { AssetId } from "./libraries/AssetId.sol";
+import { Errors } from "./libraries/Errors.sol";
+import { FixedPointMath } from "./libraries/FixedPointMath.sol";
+import { HyperdriveMath } from "./libraries/HyperdriveMath.sol";
 
 /// @author Delve
 /// @title HyperdriveLP

--- a/contracts/HyperdriveLong.sol
+++ b/contracts/HyperdriveLong.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.18;
 
-import { HyperdriveBase } from "contracts/HyperdriveBase.sol";
-import { AssetId } from "contracts/libraries/AssetId.sol";
-import { Errors } from "contracts/libraries/Errors.sol";
-import { FixedPointMath } from "contracts/libraries/FixedPointMath.sol";
-import { HyperdriveMath } from "contracts/libraries/HyperdriveMath.sol";
+import { HyperdriveBase } from "./HyperdriveBase.sol";
+import { AssetId } from "./libraries/AssetId.sol";
+import { Errors } from "./libraries/Errors.sol";
+import { FixedPointMath } from "./libraries/FixedPointMath.sol";
+import { HyperdriveMath } from "./libraries/HyperdriveMath.sol";
 
 /// @author Delve
 /// @title HyperdriveLong

--- a/contracts/HyperdriveShort.sol
+++ b/contracts/HyperdriveShort.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.18;
 
-import { HyperdriveBase } from "contracts/HyperdriveBase.sol";
-import { AssetId } from "contracts/libraries/AssetId.sol";
-import { Errors } from "contracts/libraries/Errors.sol";
-import { FixedPointMath } from "contracts/libraries/FixedPointMath.sol";
-import { HyperdriveMath } from "contracts/libraries/HyperdriveMath.sol";
+import { HyperdriveBase } from "./HyperdriveBase.sol";
+import { AssetId } from "./libraries/AssetId.sol";
+import { Errors } from "./libraries/Errors.sol";
+import { FixedPointMath } from "./libraries/FixedPointMath.sol";
+import { HyperdriveMath } from "./libraries/HyperdriveMath.sol";
 
 /// @author Delve
 /// @title HyperdriveShort

--- a/contracts/libraries/AssetId.sol
+++ b/contracts/libraries/AssetId.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.18;
 
-import { Errors } from "contracts/libraries/Errors.sol";
-import { FixedPointMath } from "contracts/libraries/FixedPointMath.sol";
+import { Errors } from "./Errors.sol";
+import { FixedPointMath } from "./FixedPointMath.sol";
 
 /// @author Delve
 /// @title Hyperdrive

--- a/contracts/libraries/HyperdriveMath.sol
+++ b/contracts/libraries/HyperdriveMath.sol
@@ -1,9 +1,9 @@
 /// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.18;
 
-import { Errors } from "contracts/libraries/Errors.sol";
-import { FixedPointMath } from "contracts/libraries/FixedPointMath.sol";
-import { YieldSpaceMath } from "contracts/libraries/YieldSpaceMath.sol";
+import { Errors } from "./Errors.sol";
+import { FixedPointMath } from "./FixedPointMath.sol";
+import { YieldSpaceMath } from "./YieldSpaceMath.sol";
 
 /// @author Delve
 /// @title Hyperdrive

--- a/contracts/libraries/YieldSpaceMath.sol
+++ b/contracts/libraries/YieldSpaceMath.sol
@@ -1,7 +1,7 @@
 /// SPDX-License-Identifier: Apache-2.0
 pragma solidity ^0.8.18;
 
-import { FixedPointMath } from "contracts/libraries/FixedPointMath.sol";
+import { FixedPointMath } from "./FixedPointMath.sol";
 
 /// @author Delve
 /// @title YieldSpaceMath


### PR DESCRIPTION
- When importing, relative paths are preferred

If you all prefer, I could do a mapping (included in the PR) for each different directory we introduce within hyperdrive, but I think that should be unnecessary and this schema seems easier for now.