### PR TITLE
Use gas reports in the benchmarking script

### DIFF
--- a/scripts/gas_benchmarks.py
+++ b/scripts/gas_benchmarks.py
@@ -4,16 +4,48 @@ import json
 
 OUTPUT_PATH = sys.argv[1]
 
+CONTRACT_NAME = "test/mocks/MockHyperdrive.sol:MockHyperdrive"
+FUNCTION_NAMES = [
+    "initialize",
+    "addLiquidity",
+    "removeLiquidity",
+    "openLong",
+    "closeLong",
+    "openShort",
+    "closeShort",
+    "checkpoint",
+]
+
 # Run the Solidity tests and write the test name and the gas used to a markdown table.
-test_output = subprocess.check_output(
-    ["forge", "test", "--match-test", "test_benchmark"]
-).decode()
-benchmark_captures = []
+test_output = subprocess.check_output(["forge", "test", "--gas-report"]).decode()
+capture = []
+found_contract = ""
+found_report = False
 for line in test_output.split("\n"):
-    if "gas:" in line:
-        test_name = line.split("(")[0].split()[-1]
-        gas_used = line.split(":")[-1].strip().split(")")[0]
-        benchmark_captures += [{"name": test_name, "value": gas_used, "unit": "gas"}]
+    if not found_contract and CONTRACT_NAME in line:
+        found_contract = True
+    if found_contract and not found_report and "Function Name" in line:
+        found_report = True
+    elif found_report and len(line) > 0:
+        cols = line.split("|")
+        function_name = cols[1].strip()
+        if function_name in FUNCTION_NAMES:
+            capture += [
+                {
+                    "name": f"{cols[1].strip()}: avg",
+                    "value": cols[3].strip(),
+                    "unit": "gas",
+                }
+            ]
+            capture += [
+                {
+                    "name": f"{cols[1].strip()}: max",
+                    "value": cols[5].strip(),
+                    "unit": "gas",
+                }
+            ]
+    elif found_report:
+        break
 
 with open(OUTPUT_PATH, "w") as f:
-    json.dump(benchmark_captures, f)
+    json.dump(capture, f)


### PR DESCRIPTION
Instead of having a benchmark test that doesn't change, we can foundry's gas report feature. This generates a markdown table of stats from the function calls in the contract. This will make it much easier to visualize the impact that changes have on important contract functions.