### PR TITLE
remove test folder from coverage report

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -37,8 +37,11 @@ jobs:
           forge coverage --report lcov
           sudo apt-get install lcov
           lcov --remove lcov.info  -o lcov.info 'test/*' 'script/*'
+
       - name: Edit lcov.info
-          run: cat lcov.info | sed '/.*\/test\/.*/,/TN:/d' > tmp.info && mv tmp.info lcov.info
+        run: |
+          cat lcov.info | sed '/.*\/test\/.*/,/TN:/d' > tmp.info && mv tmp.info lcov.info
+
       - name: Coveralls
         uses: coverallsapp/github-action@master
         with:


### PR DESCRIPTION
Mock contracts in the test folder shouldn't be included in the coverage report