### PR TITLE
Bug Fix: Burn redeemed withdrawal shares

### DIFF
--- a/contracts/src/HyperdriveLP.sol
+++ b/contracts/src/HyperdriveLP.sol
@@ -269,6 +269,13 @@ abstract contract HyperdriveLP is HyperdriveBase {
         uint256 sharePrice = _pricePerShare();
         _applyCheckpoint(_latestCheckpoint(), sharePrice);
 
+        // Burns the redeemed withdrawal shares.
+        _burn(
+            AssetId.encodeAssetId(AssetId.AssetIdPrefix.WithdrawalShare, 0),
+            msg.sender,
+            _shares
+        );
+
         // The user gets a refund on their margin equal to the face
         // value of their withdraw shares times the percent of the withdraw
         // pool which has been lost.


### PR DESCRIPTION
This PR addresses a problem where the `redeemWithdrawalShares` function didn't burn the redeemed withdrawal shares.