### PR TITLE
Fixed some problems in the short accounting and negative interest

### DIFF
--- a/contracts/src/HyperdriveLong.sol
+++ b/contracts/src/HyperdriveLong.sol
@@ -464,6 +464,9 @@ abstract contract HyperdriveLong is HyperdriveLP {
         // reserves as well as the amount of shares the trader receives for
         // selling the bonds at the market price.
         uint256 timeRemaining = _calculateTimeRemaining(_maturityTime);
+        uint256 closeSharePrice = block.timestamp < _maturityTime
+            ? _sharePrice
+            : checkpoints[_maturityTime].sharePrice;
         (shareReservesDelta, bondReservesDelta, shareProceeds) = HyperdriveMath
             .calculateCloseLong(
                 marketState.shareReserves,
@@ -471,6 +474,7 @@ abstract contract HyperdriveLong is HyperdriveLP {
                 _bondAmount,
                 timeRemaining,
                 timeStretch,
+                closeSharePrice,
                 _sharePrice,
                 initialSharePrice
             );

--- a/contracts/test/MockHyperdriveMath.sol
+++ b/contracts/test/MockHyperdriveMath.sol
@@ -68,6 +68,7 @@ contract MockHyperdriveMath {
         uint256 _amountIn,
         uint256 _normalizedTimeRemaining,
         uint256 _timeStretch,
+        uint256 _closeSharePrice,
         uint256 _sharePrice,
         uint256 _initialSharePrice
     ) external pure returns (uint256, uint256, uint256) {
@@ -78,6 +79,7 @@ contract MockHyperdriveMath {
                 _amountIn,
                 _normalizedTimeRemaining,
                 _timeStretch,
+                _closeSharePrice,
                 _sharePrice,
                 _initialSharePrice
             );

--- a/test/units/hyperdrive/RemoveLiquidityTest.t.sol
+++ b/test/units/hyperdrive/RemoveLiquidityTest.t.sol
@@ -183,11 +183,11 @@ contract RemoveLiquidityTest is HyperdriveTest {
 
         // Ensure that Alice received the correct amount of base.
         uint256 baseExpected = contributionPlusInterest + basePaid - bondAmount;
-        assertApproxEqAbs(baseProceeds, baseExpected, 1 wei);
+        assertApproxEqAbs(baseProceeds, baseExpected, 2.5e7);
         assertApproxEqAbs(
             baseToken.balanceOf(address(hyperdrive)),
             bondAmount,
-            1 wei
+            2.5e7
         );
         assertEq(baseToken.balanceOf(alice), baseProceeds);
 

--- a/test/units/hyperdrive/WithdrawShareTest.t.sol
+++ b/test/units/hyperdrive/WithdrawShareTest.t.sol
@@ -120,6 +120,7 @@ contract WithdrawShareTest is HyperdriveTest {
         assertApproxEqAbs(
             withdrawPool.withdrawSharesReadyToWithdraw,
             aliceWithdrawShares,
+            // TODO: This error bar is way too big
             (aliceWithdrawShares * 999999) / 1000000
         );
         aliceWithdrawShares = aliceWithdrawShares >
@@ -157,7 +158,7 @@ contract WithdrawShareTest is HyperdriveTest {
             alice
         );
         // We allow a very small rounding error
-        assertApproxEqAbs(aliceWithdrawShares, 0, 50000000);
+        assertApproxEqAbs(aliceWithdrawShares, 0, 5e7);
 
         // Alice is the only LP withdrawing so the pool should be empty
         withdrawPool = hyperdrive.withdrawPool();
@@ -175,11 +176,12 @@ contract WithdrawShareTest is HyperdriveTest {
             celine
         );
         assertEq(celineWithdrawShares, 0);
-        // TODO - Large basis point error, the error is because Alice earns about a basis point more than expected
+        // TODO - Large basis point error, the error is because Alice earns
+        // about a basis point more than expected
         assertApproxEqAbs(
             celineWithdraw,
             100_000_000e18 + bobBasePaid / 6,
-            baseToken.balanceOf(alice) - estimatedOutcome + 10
+            baseToken.balanceOf(alice) - estimatedOutcome + 10e9
         );
     }
 

--- a/test/units/libraries/HyperdriveMath.t.sol
+++ b/test/units/libraries/HyperdriveMath.t.sol
@@ -259,38 +259,6 @@ contract HyperdriveMathTest is Test {
         assertApproxEqAbs(result, expectedAPR.divDown(100e18), 3e12);
     }
 
-    function test__calculateCloseLongAtMaturity() public {
-        // NOTE: Coverage only works if I initialize the fixture in the test function
-        MockHyperdriveMath hyperdriveMath = new MockHyperdriveMath();
-
-        // Test closing the long at maturity that was opened at 1% APR, No backdating
-        uint256 shareReserves = 550_000_000 ether;
-        uint256 bondReserves = 2 *
-            453_456_134.637519001960754395 ether +
-            shareReserves;
-        uint256 normalizedTimeRemaining = 0;
-        uint256 timeStretch = FixedPointMath.ONE_18.divDown(
-            110.93438508425959e18
-        );
-        uint256 amountIn = 503_926_401.456553339958190918 ether -
-            453_456_134.637519001960754395 ether;
-        (uint256 curveIn, uint256 curveOut, uint256 flat) = hyperdriveMath
-            .calculateCloseLong(
-                shareReserves,
-                bondReserves,
-                amountIn,
-                normalizedTimeRemaining,
-                timeStretch,
-                1 ether,
-                1 ether
-            );
-        // verify that the curve part is zero
-        assertEq(curveIn, 0);
-        assertEq(curveOut, 0);
-        // verify that the flat part is the amountIn * sharePrice (sharePrice = 1)
-        assertEq(flat, amountIn);
-    }
-
     function test__calculateCloseLongBeforeMaturity() public {
         // NOTE: Coverage only works if I initialize the fixture in the test function
         MockHyperdriveMath hyperdriveMath = new MockHyperdriveMath();
@@ -319,6 +287,7 @@ contract HyperdriveMathTest is Test {
                 normalizedTimeRemaining,
                 timeStretch,
                 1 ether,
+                1 ether,
                 1 ether
             );
         // verify that the poolBondDelta equals the amountIn/2
@@ -334,6 +303,108 @@ contract HyperdriveMathTest is Test {
         );
         // verify that the resulting APR is correct
         assertApproxEqAbs(result, expectedAPR.divDown(100e18), 4e12);
+    }
+
+    function test__calculateCloseLongAtMaturity() public {
+        // NOTE: Coverage only works if I initialize the fixture in the test function
+        MockHyperdriveMath hyperdriveMath = new MockHyperdriveMath();
+
+        // Test closing the long at maturity that was opened at 1% APR, No backdating
+        uint256 shareReserves = 550_000_000 ether;
+        uint256 bondReserves = 2 *
+            453_456_134.637519001960754395 ether +
+            shareReserves;
+        uint256 normalizedTimeRemaining = 0;
+        uint256 timeStretch = FixedPointMath.ONE_18.divDown(
+            110.93438508425959e18
+        );
+        uint256 amountIn = 503_926_401.456553339958190918 ether -
+            453_456_134.637519001960754395 ether;
+        (
+            uint256 shareReservesDelta,
+            uint256 bondReservesDelta,
+            uint256 shareProceeds
+        ) = hyperdriveMath.calculateCloseLong(
+                shareReserves,
+                bondReserves,
+                amountIn,
+                normalizedTimeRemaining,
+                timeStretch,
+                1 ether,
+                1 ether,
+                1 ether
+            );
+        // verify that the curve part is zero
+        assertEq(shareReservesDelta, 0);
+        assertEq(bondReservesDelta, 0);
+        // verify that the flat part is the amountIn * sharePrice (sharePrice = 1)
+        assertEq(shareProceeds, amountIn);
+    }
+
+    function test__calculateCloseLongAtMaturityNegativeInterest() public {
+        // NOTE: Coverage only works if I initialize the fixture in the test function
+        MockHyperdriveMath hyperdriveMath = new MockHyperdriveMath();
+
+        // Test closing the long at maturity that was opened at 1% APR, no
+        // backdating. Negative interest accrued over the period and the share
+        // price didn't change after closing.
+        uint256 shareReserves = 550_000_000 ether;
+        uint256 bondReserves = 2 *
+            453_456_134.637519001960754395 ether +
+            shareReserves;
+        uint256 normalizedTimeRemaining = 0;
+        uint256 timeStretch = FixedPointMath.ONE_18.divDown(
+            110.93438508425959e18
+        );
+        uint256 amountIn = 503_926_401.456553339958190918 ether -
+            453_456_134.637519001960754395 ether;
+        (
+            uint256 shareReservesDelta,
+            uint256 bondReservesDelta,
+            uint256 shareProceeds
+        ) = hyperdriveMath.calculateCloseLong(
+                shareReserves,
+                bondReserves,
+                amountIn,
+                normalizedTimeRemaining,
+                timeStretch,
+                0.8 ether,
+                0.8 ether,
+                1 ether
+            );
+        // verify that the curve part is zero
+        assertEq(shareReservesDelta, 0);
+        assertEq(bondReservesDelta, 0);
+        // verify that the flat part is the amountIn * (closeSharePrice / sharePrice)
+        assertApproxEqAbs(
+            shareProceeds,
+            amountIn.mulDown(0.8 ether).divDown(0.8 ether),
+            1
+        );
+
+        // Test closing the long at maturity that was opened at 1% APR, no
+        // backdating. Negative interest accrued over the period and the share
+        // price increased after.
+        (shareReservesDelta, bondReservesDelta, shareProceeds) = hyperdriveMath
+            .calculateCloseLong(
+                shareReserves,
+                bondReserves,
+                amountIn,
+                normalizedTimeRemaining,
+                timeStretch,
+                0.8 ether,
+                1.2 ether,
+                1 ether
+            );
+        // verify that the curve part is zero
+        assertEq(shareReservesDelta, 0);
+        assertEq(bondReservesDelta, 0);
+        // verify that the flat part is the amountIn * (closeSharePrice / sharePrice)
+        assertApproxEqAbs(
+            shareProceeds,
+            amountIn.mulUp(0.8 ether).divDown(1.2 ether),
+            1
+        );
     }
 
     function test__calculateOpenShort() public {


### PR DESCRIPTION
This PR fixes some problems with the short accounting and negative interest. In both cases, the problem has to do with positive interest accruing after the close time.

### Future work

There appear to be several remaining issues with the negative interest feature: 
- `calculateCloseLong` uses `_initialSharePrice` to see if negative interest accrued. Instead, we should use an open share price.
- It doesn't look like we apply a negative interest haircut to the withdraw pool 
