### PR TITLE
Fix the "MockHyperdriveTestnet" yield source

### DIFF
--- a/contracts/test/MockHyperdriveTestnet.sol
+++ b/contracts/test/MockHyperdriveTestnet.sol
@@ -49,8 +49,7 @@ contract MockHyperdriveTestnet is Hyperdrive {
         uint256 _amount,
         bool _asUnderlying
     ) internal override returns (uint256 sharesMinted, uint256 sharePrice) {
-        // This yield source doesn't accept the underlying since it's just base.
-        if (_asUnderlying) revert UnsupportedOption();
+        if (!_asUnderlying) revert UnsupportedOption();
 
         // Accrue interest.
         accrueInterest();
@@ -82,8 +81,7 @@ contract MockHyperdriveTestnet is Hyperdrive {
         address _destination,
         bool _asUnderlying
     ) internal override returns (uint256 amountWithdrawn, uint256 sharePrice) {
-        // This yield source doesn't accept the underlying since it's just base.
-        if (_asUnderlying) revert UnsupportedOption();
+        if (!_asUnderlying) revert UnsupportedOption();
 
         // Accrue interest.
         accrueInterest();


### PR DESCRIPTION
Fixes an issue where the `asUnderlying` option was used incorrectly in the `MockHyperdriveTestnet` yield source implementation.