### PR TITLE
Prevent Re-Initialization

### DIFF
--- a/contracts/src/HyperdriveLP.sol
+++ b/contracts/src/HyperdriveLP.sol
@@ -32,7 +32,7 @@ abstract contract HyperdriveLP is HyperdriveBase {
         bool _asUnderlying
     ) external {
         // Ensure that the pool hasn't been initialized yet.
-        if (marketState.shareReserves > 0 || marketState.bondReserves > 0) {
+        if (marketState.isInitialized) {
             revert Errors.PoolAlreadyInitialized();
         }
 
@@ -44,6 +44,9 @@ abstract contract HyperdriveLP is HyperdriveBase {
 
         // Create an initial checkpoint.
         _applyCheckpoint(_latestCheckpoint(), sharePrice);
+
+        // Set the initialized state to true.
+        marketState.isInitialized = true;
 
         // Update the reserves. The bond reserves are calculated so that the
         // pool is initialized with the target APR.

--- a/contracts/src/interfaces/IHyperdrive.sol
+++ b/contracts/src/interfaces/IHyperdrive.sol
@@ -10,6 +10,7 @@ interface IHyperdrive is IMultiToken {
         uint128 bondReserves;
         uint128 longsOutstanding;
         uint128 shortsOutstanding;
+        bool isInitialized;
     }
 
     // TODO: Add documentation

--- a/test/units/hyperdrive/InitializeTest.t.sol
+++ b/test/units/hyperdrive/InitializeTest.t.sol
@@ -15,7 +15,10 @@ contract InitializeTest is HyperdriveTest {
         uint256 contribution = 1000.0e18;
 
         // Initialize the pool with Alice.
-        initialize(alice, apr, contribution);
+        uint256 lpShares = initialize(alice, apr, contribution);
+
+        // Alice removes all of her liquidity.
+        removeLiquidity(alice, lpShares);
 
         // Attempt to initialize the pool a second time. This should fail.
         vm.stopPrank();


### PR DESCRIPTION
Re-initialization is something that we could probably support safely; however, the current formulation of the `initialize` flow is unsafe as the following sequence of trades implies:

1. Alice initializes the pool.
2. Bob opens a short.
3. Alice removes her liquidity. This will result in the share reserves and bond reserves being zeroed out.
4. Bob initializes the pool with a high APR with sufficient liquidity to close his short.
5. Bob closes his short. 
6. Bob removes his liquidity. 

In order to avoid going down a rabbit-hole to fix a low-probability edge case, I have added an additional state variable (`isInitialized`) and used this to enforce that the contract has been initialized. 