### PR TITLE
fix to `collectGovernanceFee()`

### DIFF
--- a/contracts/src/HyperdriveBase.sol
+++ b/contracts/src/HyperdriveBase.sol
@@ -172,9 +172,10 @@ abstract contract HyperdriveBase is MultiToken {
     /// @notice This function collects the governance fees accrued by the pool.
     /// @return proceeds The amount of base collected.
     function collectGovernanceFee() external returns (uint256 proceeds) {
+        uint256 _governanceFeesAccrued = governanceFeesAccrued;
         governanceFeesAccrued = 0;
         // TODO: We should make an immutable asUnderlying parameter
-        (proceeds, ) = _withdraw(governanceFeesAccrued, governance, true);
+        (proceeds, ) = _withdraw(_governanceFeesAccrued, governance, true);
     }
 
     /// Getters ///


### PR DESCRIPTION
fix reentrancy issue in `collectGovernanceFee()` by ensuring that the state variable is zeroed out before withdraw is called.