### PR TITLE
Added asset IDs to all of the trading events

### DIFF
--- a/contracts/src/HyperdriveBase.sol
+++ b/contracts/src/HyperdriveBase.sol
@@ -49,6 +49,7 @@ abstract contract HyperdriveBase is MultiToken, HyperdriveStorage {
 
     event OpenLong(
         address indexed trader,
+        uint256 assetId,
         uint256 maturityTime,
         uint256 baseAmount,
         uint256 bondAmount
@@ -56,6 +57,7 @@ abstract contract HyperdriveBase is MultiToken, HyperdriveStorage {
 
     event OpenShort(
         address indexed trader,
+        uint256 assetId,
         uint256 maturityTime,
         uint256 baseAmount,
         uint256 bondAmount
@@ -63,6 +65,7 @@ abstract contract HyperdriveBase is MultiToken, HyperdriveStorage {
 
     event CloseLong(
         address indexed trader,
+        uint256 assetId,
         uint256 maturityTime,
         uint256 baseAmount,
         uint256 bondAmount
@@ -70,6 +73,7 @@ abstract contract HyperdriveBase is MultiToken, HyperdriveStorage {
 
     event CloseShort(
         address indexed trader,
+        uint256 assetId,
         uint256 maturityTime,
         uint256 baseAmount,
         uint256 bondAmount

--- a/contracts/src/HyperdriveLong.sol
+++ b/contracts/src/HyperdriveLong.sol
@@ -79,15 +79,21 @@ abstract contract HyperdriveLong is HyperdriveLP {
         );
 
         // Mint the bonds to the trader with an ID of the maturity time.
-        _mint(
-            AssetId.encodeAssetId(AssetId.AssetIdPrefix.Long, maturityTime),
-            _destination,
-            bondProceeds
+        uint256 assetId = AssetId.encodeAssetId(
+            AssetId.AssetIdPrefix.Long,
+            maturityTime
         );
+        _mint(assetId, _destination, bondProceeds);
 
         // Emit an OpenLong event.
         uint256 baseAmount = _baseAmount; // Avoid stack too deep error.
-        emit OpenLong(_destination, maturityTime, baseAmount, bondProceeds);
+        emit OpenLong(
+            _destination,
+            assetId,
+            maturityTime,
+            baseAmount,
+            bondProceeds
+        );
 
         return (bondProceeds);
     }
@@ -161,7 +167,13 @@ abstract contract HyperdriveLong is HyperdriveLP {
         if (_minOutput > baseProceeds) revert Errors.OutputLimit();
 
         // Emit a CloseLong event.
-        emit CloseLong(_destination, _maturityTime, baseProceeds, _bondAmount);
+        emit CloseLong(
+            _destination,
+            AssetId.encodeAssetId(AssetId.AssetIdPrefix.Long, _maturityTime),
+            _maturityTime,
+            baseProceeds,
+            _bondAmount
+        );
 
         return (baseProceeds);
     }

--- a/contracts/src/HyperdriveShort.sol
+++ b/contracts/src/HyperdriveShort.sol
@@ -92,15 +92,21 @@ abstract contract HyperdriveShort is HyperdriveLP {
 
         // Mint the short tokens to the trader. The ID is a concatenation of the
         // current share price and the maturity time of the shorts.
-        _mint(
-            AssetId.encodeAssetId(AssetId.AssetIdPrefix.Short, maturityTime),
-            _destination,
-            _bondAmount
+        uint256 assetId = AssetId.encodeAssetId(
+            AssetId.AssetIdPrefix.Short,
+            maturityTime
         );
+        _mint(assetId, _destination, _bondAmount);
 
         // Emit an OpenShort event.
         uint256 bondAmount = _bondAmount; // Avoid stack too deep error.
-        emit OpenShort(_destination, maturityTime, traderDeposit, bondAmount);
+        emit OpenShort(
+            _destination,
+            assetId,
+            maturityTime,
+            traderDeposit,
+            bondAmount
+        );
 
         return (traderDeposit);
     }
@@ -188,7 +194,13 @@ abstract contract HyperdriveShort is HyperdriveLP {
         // Emit a CloseShort event.
         uint256 maturityTime = _maturityTime; // Avoid stack too deep error.
         uint256 bondAmount = _bondAmount; // Avoid stack too deep error.
-        emit CloseShort(_destination, maturityTime, baseProceeds, bondAmount);
+        emit CloseShort(
+            _destination,
+            AssetId.encodeAssetId(AssetId.AssetIdPrefix.Short, maturityTime),
+            maturityTime,
+            baseProceeds,
+            bondAmount
+        );
 
         return baseProceeds;
     }

--- a/test/units/hyperdrive/CloseLongTest.t.sol
+++ b/test/units/hyperdrive/CloseLongTest.t.sol
@@ -460,10 +460,15 @@ contract CloseLongTest is HyperdriveTest {
             VmSafe.Log memory log = logs[0];
             assertEq(address(uint160(uint256(log.topics[1]))), bob);
             (
+                uint256 eventAssetId,
                 uint256 eventMaturityTime,
                 uint256 eventBaseAmount,
                 uint256 eventBondAmount
-            ) = abi.decode(log.data, (uint256, uint256, uint256));
+            ) = abi.decode(log.data, (uint256, uint256, uint256, uint256));
+            assertEq(
+                eventAssetId,
+                AssetId.encodeAssetId(AssetId.AssetIdPrefix.Long, maturityTime)
+            );
             assertEq(eventMaturityTime, maturityTime);
             assertEq(eventBaseAmount, baseProceeds);
             assertEq(eventBondAmount, bondAmount);

--- a/test/units/hyperdrive/CloseShortTest.t.sol
+++ b/test/units/hyperdrive/CloseShortTest.t.sol
@@ -361,10 +361,15 @@ contract CloseShortTest is HyperdriveTest {
             VmSafe.Log memory log = logs[0];
             assertEq(address(uint160(uint256(log.topics[1]))), bob);
             (
+                uint256 eventAssetId,
                 uint256 eventMaturityTime,
                 uint256 eventBaseAmount,
                 uint256 eventBondAmount
-            ) = abi.decode(log.data, (uint256, uint256, uint256));
+            ) = abi.decode(log.data, (uint256, uint256, uint256, uint256));
+            assertEq(
+                eventAssetId,
+                AssetId.encodeAssetId(AssetId.AssetIdPrefix.Short, maturityTime)
+            );
             assertEq(eventMaturityTime, maturityTime);
             assertEq(eventBaseAmount, baseProceeds);
             assertEq(eventBondAmount, bondAmount);

--- a/test/units/hyperdrive/OpenLongTest.t.sol
+++ b/test/units/hyperdrive/OpenLongTest.t.sol
@@ -147,10 +147,15 @@ contract OpenLongTest is HyperdriveTest {
             VmSafe.Log memory log = logs[0];
             assertEq(address(uint160(uint256(log.topics[1]))), bob);
             (
+                uint256 eventAssetId,
                 uint256 eventMaturityTime,
                 uint256 eventBaseAmount,
                 uint256 eventBondAmount
-            ) = abi.decode(log.data, (uint256, uint256, uint256));
+            ) = abi.decode(log.data, (uint256, uint256, uint256, uint256));
+            assertEq(
+                eventAssetId,
+                AssetId.encodeAssetId(AssetId.AssetIdPrefix.Long, maturityTime)
+            );
             assertEq(eventMaturityTime, maturityTime);
             assertEq(eventBaseAmount, baseAmount);
             assertEq(eventBondAmount, bondAmount);

--- a/test/units/hyperdrive/OpenShortTest.t.sol
+++ b/test/units/hyperdrive/OpenShortTest.t.sol
@@ -138,10 +138,15 @@ contract OpenShortTest is HyperdriveTest {
             VmSafe.Log memory log = logs[0];
             assertEq(address(uint160(uint256(log.topics[1]))), bob);
             (
+                uint256 eventAssetId,
                 uint256 eventMaturityTime,
                 uint256 eventBaseAmount,
                 uint256 eventBondAmount
-            ) = abi.decode(log.data, (uint256, uint256, uint256));
+            ) = abi.decode(log.data, (uint256, uint256, uint256, uint256));
+            assertEq(
+                eventAssetId,
+                AssetId.encodeAssetId(AssetId.AssetIdPrefix.Short, maturityTime)
+            );
             assertEq(eventMaturityTime, maturityTime);
             assertEq(eventBaseAmount, baseAmount);
             assertEq(eventBondAmount, bondAmount);

--- a/test/utils/HyperdriveTest.sol
+++ b/test/utils/HyperdriveTest.sol
@@ -297,6 +297,7 @@ contract HyperdriveTest is BaseTest {
 
     event OpenLong(
         address indexed trader,
+        uint256 assetId,
         uint256 maturityTime,
         uint256 baseAmount,
         uint256 bondAmount
@@ -304,6 +305,7 @@ contract HyperdriveTest is BaseTest {
 
     event OpenShort(
         address indexed trader,
+        uint256 assetId,
         uint256 maturityTime,
         uint256 baseAmount,
         uint256 bondAmount
@@ -311,6 +313,7 @@ contract HyperdriveTest is BaseTest {
 
     event CloseLong(
         address indexed trader,
+        uint256 assetId,
         uint256 maturityTime,
         uint256 baseAmount,
         uint256 bondAmount
@@ -318,6 +321,7 @@ contract HyperdriveTest is BaseTest {
 
     event CloseShort(
         address indexed trader,
+        uint256 assetId,
         uint256 maturityTime,
         uint256 baseAmount,
         uint256 bondAmount


### PR DESCRIPTION
To improve the DevEx of using Hyperdrive, @DannyDelott suggested that we add the asset ID of longs and shorts to the `OpenLong`, `CloseLong`, `OpenShort`, and `CloseShort` events.