### PR TITLE
Adds a sweep function 

### DIFF
--- a/contracts/src/instances/ERC4626Hyperdrive.sol
+++ b/contracts/src/instances/ERC4626Hyperdrive.sol
@@ -141,11 +141,15 @@ contract ERC4626Hyperdrive is Hyperdrive {
     ///                integrating contracts should be checked for that, as it may result in an unexpected call
     ///                from this address.
     function sweep(IERC20 token) external {
-        // TODO - Should we add a governance lock?
+        // Only governance address can call
+        if (msg.sender != _feeCollector && !_pausers[msg.sender])
+            revert Errors.Unauthorized();
+        // Cannot rug the yield source or base token
         if (
             address(token) == address(pool) ||
             address(token) == address(_baseToken)
         ) revert Errors.UnsupportedToken();
+        // Transfer to the fee collector
         uint256 balance = token.balanceOf(address(this));
         token.transfer(_feeCollector, balance);
     }


### PR DESCRIPTION
The morpho token distribution system will let anyone call to distribute rewards but the tokens will get stuck in the hyperdrive contract unless they are swept. We add a function which lets any stuck tokens be distributed to the _feeCollector address.