### PR TITLE
add multiblock rt test

### DIFF
--- a/test/integrations/hyperdrive/RoundTripTest.t.sol
+++ b/test/integrations/hyperdrive/RoundTripTest.t.sol
@@ -56,7 +56,7 @@ contract RoundTripTest is HyperdriveTest {
         advanceTime(CHECKPOINT_DURATION / 2, 0);
 
         // Open a long position.
-        uint256 basePaid = 50_000_000e18;
+        uint256 basePaid = 10e18;
         (uint256 maturityTime, uint256 bondAmount) = openLong(bob, basePaid);
 
         // Immediately close the long.


### PR DESCRIPTION
Added a test for this scenario:

- user opens a long right before checkpoint boundary
- waits a block
- then closes long

the test shows that this isn't profitable in the following conditions:

- position duration: 1 year
- checkpoint length: 1 day
- aprs ranging from: 0.1% to 40%

With the following fees
- curve: 5% of APR
- flat: 5 bps

