### PR TITLE
Adds `getRate` to `MockHyperdriveTestnet`

### DIFF
--- a/contracts/test/MockHyperdriveTestnet.sol
+++ b/contracts/test/MockHyperdriveTestnet.sol
@@ -183,6 +183,10 @@ contract MockHyperdriveDataProviderTestnet is
         MultiTokenDataProvider(_linkerCodeHash, _factory)
     {}
 
+    function getRate() external view returns (uint256) {
+        _revert(abi.encode(rate));
+    }
+
     /// Overrides ///
 
     function _pricePerShare() internal view override returns (uint256) {


### PR DESCRIPTION
To make it possible to display the current variable rate in the internal trading competition, it needs to have access to the current yield source's rate. 