### PR TITLE
Fix intermittent fuzz test failuires

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -33,7 +33,7 @@ gas_reports = ["*"]
 evm_version = "paris"
 
 [fuzz]
-runs = 100_000
+runs = 1000
 
 [rpc_endpoints]
 mainnet = "${MAINNET_RPC_URL}"


### PR DESCRIPTION
Uniswap uses `uint128` so its a safe bound to use for amounts, and higher than we will ever likely see, appears to fix this fuzz test failure as test locally with 100,00 runs
```
❯ forge test --match-test test_CloseShortWithUnderlying
[⠰] Compiling...
No files changed, compilation skipped

Running 1 test for test/integrations/sDai.t.sol:sDaiTest
[PASS] test_CloseShortWithUnderlying(uint128,int256) (runs: 100000, μ: 468815, ~: 468808)
Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 159.77s

Running 1 test for test/integrations/AaveV3ERC4626.t.sol:AaveV3ERC4626Test
[PASS] test_CloseShortWithUnderlying(uint128,int256) (runs: 100000, μ: 544864, ~: 544852)
Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 240.46s

Running 1 test for test/integrations/StethERC4626.t.sol:StethERC4626
[PASS] test_CloseShortWithUnderlying(uint128,int256) (runs: 100000, μ: 482253, ~: 482218)
Test result: ok. 1 passed; 0 failed; 0 skipped; finished in 335.32s
Ran 3 test suites: 3 tests passed, 0 failed, 0 skipped (3 total tests)
```