### PR TITLE
Downgraded the foundry version in the coverage CI action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -35,7 +35,9 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          # TODO: We should just use nightly, but downgrading to fix a reversion
+          # in forge coverage.
+          version: nightly-10440422e63aae660104e079dfccd5b0ae5fd720
 
       - name: Run coverage
         run: |


### PR DESCRIPTION
This fixes an issue caused by the latest foundry release. We have an open issue on the foundry repo to track this: https://github.com/foundry-rs/foundry/issues/5609. While they work on fixing this, we can just downgrade to the last release.