### PR TITLE
Replace "apr" with "spot rate" and other refactoring

### DIFF
--- a/contracts/src/HyperdriveBase.sol
+++ b/contracts/src/HyperdriveBase.sol
@@ -26,7 +26,7 @@ abstract contract HyperdriveBase is MultiToken, HyperdriveStorage {
         address indexed provider,
         uint256 lpAmount,
         uint256 baseAmount,
-        uint256 apr
+        uint256 spotRate
     );
 
     event AddLiquidity(

--- a/contracts/src/factory/ERC4626HyperdriveFactory.sol
+++ b/contracts/src/factory/ERC4626HyperdriveFactory.sol
@@ -65,12 +65,12 @@ contract ERC4626HyperdriveFactory is HyperdriveFactory {
     /// @notice This deploys and initializes a new ERC4626Hyperdrive instance.
     /// @param _config The pool configuration.
     /// @param _contribution The contribution amount.
-    /// @param _apr The initial spot rate.
+    /// @param _spotRate The initial spot rate.
     function deployAndInitialize(
         IHyperdrive.PoolConfig memory _config,
         bytes32[] memory,
         uint256 _contribution,
-        uint256 _apr
+        uint256 _spotRate
     ) public payable override returns (IHyperdrive) {
         // Deploy and initialize the ERC4626 hyperdrive instance with the
         // default sweep targets provided as extra data.
@@ -83,7 +83,7 @@ contract ERC4626HyperdriveFactory is HyperdriveFactory {
             _config,
             extraData,
             _contribution,
-            _apr
+            _spotRate
         );
 
         // Return the hyperdrive instance.

--- a/contracts/src/factory/HyperdriveFactory.sol
+++ b/contracts/src/factory/HyperdriveFactory.sol
@@ -158,7 +158,9 @@ abstract contract HyperdriveFactory {
         hyperdriveDeployer = newDeployer;
 
         // Increment the version number.
-        unchecked {++versionCounter;}
+        unchecked {
+            ++versionCounter;
+        }
 
         emit ImplementationUpdated(address(newDeployer));
     }
@@ -236,15 +238,15 @@ abstract contract HyperdriveFactory {
     ///      to accept ether on initialization, but payability is not supported
     ///      by default.
     /// @param _config The configuration of the Hyperdrive pool.
-    /// @param _extraData The extra data is used by some factories
-    /// @param _contribution Base token to call init with
-    /// @param _apr The apr to call init with
+    /// @param _extraData The extra data. This is used by some factories.
+    /// @param _contribution The initial contribution.
+    /// @param _spotRate The target spot rate.
     /// @return The hyperdrive address deployed
     function deployAndInitialize(
         IHyperdrive.PoolConfig memory _config,
         bytes32[] memory _extraData,
         uint256 _contribution,
-        uint256 _apr
+        uint256 _spotRate
     ) public payable virtual returns (IHyperdrive) {
         if (msg.value > 0) {
             revert IHyperdrive.NonPayableInitialization();
@@ -259,7 +261,7 @@ abstract contract HyperdriveFactory {
         _config.feeCollector = feeCollector;
         _config.governance = address(this);
         _config.fees = fees;
-        bytes32 _linkerCodeHash = linkerCodeHash; 
+        bytes32 _linkerCodeHash = linkerCodeHash;
         address _linkerFactory = linkerFactory;
         address dataProvider = deployDataProvider(
             _config,
@@ -298,13 +300,15 @@ abstract contract HyperdriveFactory {
         ) {
             revert IHyperdrive.ApprovalFailed();
         }
-        hyperdrive.initialize(_contribution, _apr, msg.sender, true);
+        hyperdrive.initialize(_contribution, _spotRate, msg.sender, true);
 
         // Set the default pausers and transfer the governance status to the
         // hyperdrive governance address.
         for (uint256 i = 0; i < _defaultPausers.length; ) {
             hyperdrive.setPauser(_defaultPausers[i], true);
-            unchecked {++i;}
+            unchecked {
+                ++i;
+            }
         }
         hyperdrive.setGovernance(hyperdriveGovernance);
 

--- a/contracts/src/interfaces/IHyperdrive.sol
+++ b/contracts/src/interfaces/IHyperdrive.sol
@@ -13,7 +13,7 @@ interface IHyperdrive is IHyperdriveRead, IHyperdriveWrite, IMultiToken {
         address indexed provider,
         uint256 lpAmount,
         uint256 baseAmount,
-        uint256 apr
+        uint256 spotRate
     );
 
     event AddLiquidity(
@@ -207,16 +207,16 @@ interface IHyperdrive is IHyperdriveRead, IHyperdriveWrite, IMultiToken {
     error BaseBufferExceedsShareReserves();
     error BelowMinimumContribution();
     error BelowMinimumShareReserves();
-    error InvalidApr();
     error InvalidBaseToken();
     error InvalidCheckpointTime();
     error InvalidCheckpointDuration();
+    error InvalidFeeAmounts();
     error InvalidInitialSharePrice();
     error InvalidMaturityTime();
     error InvalidMinimumShareReserves();
     error InvalidPositionDuration();
     error InvalidShareReserves();
-    error InvalidFeeAmounts();
+    error InvalidSpotRate();
     error NegativeInterest();
     error NegativePresentValue();
     error NoAssetsToWithdraw();

--- a/contracts/src/interfaces/IHyperdriveWrite.sol
+++ b/contracts/src/interfaces/IHyperdriveWrite.sol
@@ -12,15 +12,15 @@ interface IHyperdriveWrite is IMultiTokenWrite {
 
     function initialize(
         uint256 _contribution,
-        uint256 _apr,
+        uint256 _spotRate,
         address _destination,
         bool _asUnderlying
     ) external payable returns (uint256 lpShares);
 
     function addLiquidity(
         uint256 _contribution,
-        uint256 _minApr,
-        uint256 _maxApr,
+        uint256 _minSpotRate,
+        uint256 _maxSpotRate,
         address _destination,
         bool _asUnderlying
     ) external payable returns (uint256 lpShares);

--- a/contracts/test/MockHyperdriveMath.sol
+++ b/contracts/test/MockHyperdriveMath.sol
@@ -4,14 +4,14 @@ pragma solidity 0.8.19;
 import { HyperdriveMath } from "../src/libraries/HyperdriveMath.sol";
 
 contract MockHyperdriveMath {
-    function calculateAPRFromReserves(
+    function calculateSpotRate(
         uint256 _shareReserves,
         uint256 _bondReserves,
         uint256 _initialSharePrice,
         uint256 _positionDuration,
         uint256 _timeStretch
     ) external pure returns (uint256) {
-        uint256 result = HyperdriveMath.calculateAPRFromReserves(
+        uint256 result = HyperdriveMath.calculateSpotRate(
             _shareReserves,
             _bondReserves,
             _initialSharePrice,
@@ -24,14 +24,14 @@ contract MockHyperdriveMath {
     function calculateInitialBondReserves(
         uint256 _shareReserves,
         uint256 _initialSharePrice,
-        uint256 _apr,
+        uint256 _spotRate,
         uint256 _positionDuration,
         uint256 _timeStretch
     ) external pure returns (uint256) {
         uint256 result = HyperdriveMath.calculateInitialBondReserves(
             _shareReserves,
             _initialSharePrice,
-            _apr,
+            _spotRate,
             _positionDuration,
             _timeStretch
         );

--- a/test/integrations/ERC4626Hyperdrive.t.sol
+++ b/test/integrations/ERC4626Hyperdrive.t.sol
@@ -156,7 +156,7 @@ contract ERC4626HyperdriveTest is HyperdriveTest {
 
     function test_erc4626_testDeploy() external {
         vm.startPrank(alice);
-        uint256 apr = 0.01e18; // 1% apr
+        uint256 fixedRate = 0.01e18; // 1% fixed rate
         uint256 contribution = 2_500e18;
         IHyperdrive.PoolConfig memory config = IHyperdrive.PoolConfig({
             baseToken: dai,
@@ -165,7 +165,7 @@ contract ERC4626HyperdriveTest is HyperdriveTest {
             minimumTransactionAmount: 0.001e18,
             positionDuration: 365 days,
             checkpointDuration: 1 days,
-            timeStretch: HyperdriveUtils.calculateTimeStretch(apr),
+            timeStretch: HyperdriveUtils.calculateTimeStretch(fixedRate),
             governance: alice,
             feeCollector: bob,
             fees: IHyperdrive.Fees(0, 0, 0),
@@ -177,7 +177,7 @@ contract ERC4626HyperdriveTest is HyperdriveTest {
             config,
             new bytes32[](0),
             contribution,
-            apr
+            fixedRate
         );
 
         // The initial price per share is one so the LP shares will initially
@@ -194,7 +194,7 @@ contract ERC4626HyperdriveTest is HyperdriveTest {
             factory,
             alice,
             contribution,
-            apr,
+            fixedRate,
             config.minimumShareReserves,
             new bytes32[](0),
             0
@@ -205,7 +205,7 @@ contract ERC4626HyperdriveTest is HyperdriveTest {
         // This test makes sure that the ERC4626DataProvider function returns
         // the correct share price.
         vm.startPrank(alice);
-        uint256 apr = 0.01e18; // 1% apr
+        uint256 fixedRate = 0.01e18; // 1% fixed rate
         uint256 contribution = 2_500e18;
         IHyperdrive.PoolConfig memory config = IHyperdrive.PoolConfig({
             baseToken: dai,
@@ -214,7 +214,7 @@ contract ERC4626HyperdriveTest is HyperdriveTest {
             minimumTransactionAmount: 0.001e18,
             positionDuration: 365 days,
             checkpointDuration: 1 days,
-            timeStretch: HyperdriveUtils.calculateTimeStretch(apr),
+            timeStretch: HyperdriveUtils.calculateTimeStretch(fixedRate),
             governance: alice,
             feeCollector: bob,
             fees: IHyperdrive.Fees(0, 0, 0),
@@ -226,7 +226,7 @@ contract ERC4626HyperdriveTest is HyperdriveTest {
             config,
             new bytes32[](0),
             contribution,
-            apr
+            fixedRate
         );
 
         // Ensure the share price is 1 after initialization.

--- a/test/integrations/ERC4626Validation.t.sol
+++ b/test/integrations/ERC4626Validation.t.sol
@@ -313,7 +313,7 @@ abstract contract ERC4626ValidationTest is HyperdriveTest {
         (, uint256 basePaid) = openShortERC4626(alice, shortAmount, true);
 
         // Ensure that the amount of base paid by the short is reasonable.
-        uint256 realizedRate = HyperdriveUtils.calculateAPRFromRealizedPrice(
+        uint256 realizedRate = HyperdriveUtils.calculateRateFromRealizedPrice(
             shortAmount - basePaid,
             shortAmount,
             1e18
@@ -361,7 +361,7 @@ abstract contract ERC4626ValidationTest is HyperdriveTest {
 
         // Ensure we did actually paid a non-Zero amount of base
         assertGt(basePaid, 0);
-        uint256 realizedRate = HyperdriveUtils.calculateAPRFromRealizedPrice(
+        uint256 realizedRate = HyperdriveUtils.calculateRateFromRealizedPrice(
             shortAmount - basePaid,
             shortAmount,
             1e18

--- a/test/integrations/hyperdrive/IntraCheckpointNettingTest.t.sol
+++ b/test/integrations/hyperdrive/IntraCheckpointNettingTest.t.sol
@@ -19,10 +19,10 @@ contract IntraCheckpointNettingTest is HyperdriveTest {
         uint256 initialSharePrice = 1e18;
 
         // Initialize the market
-        uint256 apr = 0.05e18;
-        deploy(alice, apr, initialSharePrice, 0, 0, 0);
+        uint256 fixedRate = 0.05e18;
+        deploy(alice, fixedRate, initialSharePrice, 0, 0, 0);
         uint256 contribution = 100e18;
-        uint256 aliceLpShares = initialize(alice, apr, contribution);
+        uint256 aliceLpShares = initialize(alice, fixedRate, contribution);
 
         // open a short
         uint256 shortAmount = 10e18;
@@ -79,10 +79,10 @@ contract IntraCheckpointNettingTest is HyperdriveTest {
         // initialize the market
         uint256 aliceLpShares = 0;
         {
-            uint256 apr = 0.05e18;
-            deploy(alice, apr, initialSharePrice, 0, 0, 0);
+            uint256 fixedRate = 0.05e18;
+            deploy(alice, fixedRate, initialSharePrice, 0, 0, 0);
             uint256 contribution = 500_000_000e18;
-            aliceLpShares = initialize(alice, apr, contribution);
+            aliceLpShares = initialize(alice, fixedRate, contribution);
 
             // fast forward time and accrue interest
             advanceTime(POSITION_DURATION, 0);
@@ -156,10 +156,10 @@ contract IntraCheckpointNettingTest is HyperdriveTest {
         // initialize the market
         uint256 aliceLpShares = 0;
         {
-            uint256 apr = 0.05e18;
-            deploy(alice, apr, initialSharePrice, 0, 0, 0);
+            uint256 fixedRate = 0.05e18;
+            deploy(alice, fixedRate, initialSharePrice, 0, 0, 0);
             uint256 contribution = 500_000_000e18;
-            aliceLpShares = initialize(alice, apr, contribution);
+            aliceLpShares = initialize(alice, fixedRate, contribution);
 
             // fast forward time and accrue interest
             advanceTime(POSITION_DURATION, 0);
@@ -432,10 +432,10 @@ contract IntraCheckpointNettingTest is HyperdriveTest {
         uint256 numTrades
     ) internal {
         // Initialize the market
-        uint256 apr = 0.05e18;
-        deploy(alice, apr, initialSharePrice, 0, 0, 0);
+        uint256 fixedRate = 0.05e18;
+        deploy(alice, fixedRate, initialSharePrice, 0, 0, 0);
         uint256 contribution = 500_000_000e18;
-        uint256 aliceLpShares = initialize(alice, apr, contribution);
+        uint256 aliceLpShares = initialize(alice, fixedRate, contribution);
 
         // fast forward time and accrue interest
         advanceTime(POSITION_DURATION, variableInterest);
@@ -568,10 +568,10 @@ contract IntraCheckpointNettingTest is HyperdriveTest {
         uint256 numTrades
     ) internal {
         // Initialize the market
-        uint256 apr = 0.05e18;
-        deploy(alice, apr, initialSharePrice, 0, 0, 0);
+        uint256 fixedRate = 0.05e18;
+        deploy(alice, fixedRate, initialSharePrice, 0, 0, 0);
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // fast forward time and accrue interest
         advanceTime(POSITION_DURATION, variableInterest);
@@ -724,10 +724,10 @@ contract IntraCheckpointNettingTest is HyperdriveTest {
         uint256 numTrades
     ) internal {
         // initialize the market
-        uint256 apr = 0.05e18;
-        deploy(alice, apr, initialSharePrice, 0, 0, 0);
+        uint256 fixedRate = 0.05e18;
+        deploy(alice, fixedRate, initialSharePrice, 0, 0, 0);
         uint256 contribution = 500_000_000e18;
-        uint256 aliceLpShares = initialize(alice, apr, contribution);
+        uint256 aliceLpShares = initialize(alice, fixedRate, contribution);
 
         // fast forward time and accrue interest
         advanceTime(POSITION_DURATION, variableInterest);
@@ -794,10 +794,10 @@ contract IntraCheckpointNettingTest is HyperdriveTest {
         // initialize the market
         uint256 aliceLpShares = 0;
         {
-            uint256 apr = 0.05e18;
-            deploy(alice, apr, initialSharePrice, 0, 0, 0);
+            uint256 fixedRate = 0.05e18;
+            deploy(alice, fixedRate, initialSharePrice, 0, 0, 0);
             uint256 contribution = 500_000_000e18;
-            aliceLpShares = initialize(alice, apr, contribution);
+            aliceLpShares = initialize(alice, fixedRate, contribution);
 
             // fast forward time and accrue interest
             advanceTime(POSITION_DURATION, variableInterest);

--- a/test/integrations/hyperdrive/LpWithdrawalTest.t.sol
+++ b/test/integrations/hyperdrive/LpWithdrawalTest.t.sol
@@ -48,20 +48,20 @@ contract LpWithdrawalTest is HyperdriveTest {
         uint256 basePaid,
         int256 preTradingVariableRate
     ) external {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
         uint256 contribution = 500_000_000e18;
-        uint256 lpShares = initialize(alice, apr, contribution);
+        uint256 lpShares = initialize(alice, fixedRate, contribution);
 
-        // TODO: We run into subtraction underflows when the pre trading APR is
-        // negative because the spot price goes above 1. We should investigate
-        // this further. The specific error is caused by a spot price that is 1
-        // or 2 wei greater than 1e18:
+        // TODO: We run into subtraction underflows when the pre trading
+        // variable rate is negative because the spot price goes above 1. We
+        // should investigate this further. The specific error is caused by a
+        // spot price that is 1 or 2 wei greater than 1e18:
         //
         // FAIL. Reason: FixedPointMath_SubOverflow() Counterexample: calldata=0xeb03bc3c00000000000000000000000000000000000000000056210439729b8099325834fffffffffffffffffffffffffffffffffffffffffffffffff923591560ca3e4c, args=[104123536507311086290229300, -494453585727570356]]
         //
         // Accrue interest before the trading period.
         preTradingVariableRate = preTradingVariableRate.normalizeToRange(
-            0e18,
+            0,
             1e18
         );
         advanceTime(POSITION_DURATION, preTradingVariableRate);
@@ -126,9 +126,9 @@ contract LpWithdrawalTest is HyperdriveTest {
         uint256 basePaid,
         int256 variableRate
     ) external {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
         uint256 contribution = 500_000_000e18;
-        uint256 lpShares = initialize(alice, apr, contribution);
+        uint256 lpShares = initialize(alice, fixedRate, contribution);
         contribution -= 2 * hyperdrive.getPoolConfig().minimumShareReserves;
 
         // Bob opens a max long.
@@ -208,9 +208,9 @@ contract LpWithdrawalTest is HyperdriveTest {
     // The LPs should be able to remove their liqudity without an
     // arithmetic underflow.
     function test_lp_withdrawal_too_many_longs() external {
-        uint256 apr = 0.10e18;
+        uint256 fixedRate = 0.10e18;
         uint256 contribution = 1e18;
-        uint256 lpShares = initialize(alice, apr, contribution);
+        uint256 lpShares = initialize(alice, fixedRate, contribution);
         contribution -= 2 * hyperdrive.getPoolConfig().minimumShareReserves;
 
         // Celine adds liquidity.
@@ -237,13 +237,13 @@ contract LpWithdrawalTest is HyperdriveTest {
         uint256 shortAmount,
         int256 preTradingVariableRate
     ) external {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
         uint256 contribution = 500_000_000e18;
-        uint256 lpShares = initialize(alice, apr, contribution);
+        uint256 lpShares = initialize(alice, fixedRate, contribution);
 
-        // TODO: We run into subtraction underflows when the pre trading APR is
-        // negative because the spot price goes above 1. We should investigate
-        // this further.
+        // TODO: We run into subtraction underflows when the pre trading
+        // variable rate is negative because the spot price goes above 1. We
+        // should investigate this further.
         //
         // Accrue interest before the trading period.
         preTradingVariableRate = preTradingVariableRate.normalizeToRange(
@@ -300,9 +300,9 @@ contract LpWithdrawalTest is HyperdriveTest {
         uint256 shortAmount,
         int256 variableRate
     ) external {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
         uint256 contribution = 500_000_000e18;
-        uint256 lpShares = initialize(alice, apr, contribution);
+        uint256 lpShares = initialize(alice, fixedRate, contribution);
         contribution -= 2 * hyperdrive.getPoolConfig().minimumShareReserves;
 
         // Bob opens a large short.
@@ -640,7 +640,7 @@ contract LpWithdrawalTest is HyperdriveTest {
         snapshotId = vm.snapshot();
         {
             uint256 longBasePaid = 47622440666488;
-            uint256 shortAmount = 99991360285271; 
+            uint256 shortAmount = 99991360285271;
             int256 variableRate = 25629;
             _test_lp_withdrawal_long_short_redemption(
                 longBasePaid,

--- a/test/integrations/hyperdrive/NegativeInterestLongFeeTest.t.sol
+++ b/test/integrations/hyperdrive/NegativeInterestLongFeeTest.t.sol
@@ -104,10 +104,17 @@ contract NegativeInterestLongFeeTest is HyperdriveTest {
         uint256 governanceFee
     ) internal {
         // Initialize the market
-        uint256 apr = 0.05e18;
-        deploy(alice, apr, initialSharePrice, curveFee, flatFee, governanceFee);
+        uint256 fixedRate = 0.05e18;
+        deploy(
+            alice,
+            fixedRate,
+            initialSharePrice,
+            curveFee,
+            flatFee,
+            governanceFee
+        );
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // fast forward time and accrue interest
         advanceTime(POSITION_DURATION, variableInterest);
@@ -299,10 +306,17 @@ contract NegativeInterestLongFeeTest is HyperdriveTest {
         uint256 governanceFee
     ) internal {
         // Initialize the market
-        uint256 apr = 0.05e18;
-        deploy(alice, apr, initialSharePrice, curveFee, flatFee, governanceFee);
+        uint256 fixedRate = 0.05e18;
+        deploy(
+            alice,
+            fixedRate,
+            initialSharePrice,
+            curveFee,
+            flatFee,
+            governanceFee
+        );
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // fast forward time and accrue interest
         advanceTime(POSITION_DURATION, preTradeVariableInterest);
@@ -490,10 +504,17 @@ contract NegativeInterestLongFeeTest is HyperdriveTest {
         uint256 governanceFee
     ) internal {
         // Initialize the market
-        uint256 apr = 0.05e18;
-        deploy(alice, apr, initialSharePrice, curveFee, flatFee, governanceFee);
+        uint256 fixedRate = 0.05e18;
+        deploy(
+            alice,
+            fixedRate,
+            initialSharePrice,
+            curveFee,
+            flatFee,
+            governanceFee
+        );
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // fast forward time and accrue interest
         advanceTime(POSITION_DURATION, preTradeVariableInterest);

--- a/test/integrations/hyperdrive/NegativeInterestShortFeeTest.t.sol
+++ b/test/integrations/hyperdrive/NegativeInterestShortFeeTest.t.sol
@@ -104,10 +104,17 @@ contract NegativeInterestShortFeeTest is HyperdriveTest {
         uint256 governanceFee
     ) internal {
         // Initialize the market
-        uint256 apr = 0.05e18;
-        deploy(alice, apr, initialSharePrice, curveFee, flatFee, governanceFee);
+        uint256 fixedRate = 0.05e18;
+        deploy(
+            alice,
+            fixedRate,
+            initialSharePrice,
+            curveFee,
+            flatFee,
+            governanceFee
+        );
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // fast forward time and accrue interest
         advanceTime(POSITION_DURATION, variableInterest);
@@ -289,10 +296,17 @@ contract NegativeInterestShortFeeTest is HyperdriveTest {
         uint256 governanceFee
     ) internal {
         // Initialize the market
-        uint256 apr = 0.05e18;
-        deploy(alice, apr, initialSharePrice, curveFee, flatFee, governanceFee);
+        uint256 fixedRate = 0.05e18;
+        deploy(
+            alice,
+            fixedRate,
+            initialSharePrice,
+            curveFee,
+            flatFee,
+            governanceFee
+        );
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // fast forward time and accrue interest
         advanceTime(POSITION_DURATION, preTradeVariableInterest);
@@ -488,10 +502,17 @@ contract NegativeInterestShortFeeTest is HyperdriveTest {
         uint256 governanceFee
     ) internal {
         // Initialize the market
-        uint256 apr = 0.05e18;
-        deploy(alice, apr, initialSharePrice, curveFee, flatFee, governanceFee);
+        uint256 fixedRate = 0.05e18;
+        deploy(
+            alice,
+            fixedRate,
+            initialSharePrice,
+            curveFee,
+            flatFee,
+            governanceFee
+        );
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // fast forward time and accrue interest
         advanceTime(POSITION_DURATION, preTradeVariableInterest);

--- a/test/integrations/hyperdrive/NonstandardDecimals.sol
+++ b/test/integrations/hyperdrive/NonstandardDecimals.sol
@@ -28,16 +28,16 @@ contract NonstandardDecimalsTest is HyperdriveTest {
     }
 
     function test_nonstandard_decimals_initialize(
-        uint256 apr,
+        uint256 fixedRate,
         uint256 contribution
     ) external {
         // Normalize the fuzzed variables.
-        apr = apr.normalizeToRange(0.001e18, 2e18);
+        fixedRate = fixedRate.normalizeToRange(0.001e18, 2e18);
         contribution = contribution.normalizeToRange(2e6, 1_000_000_000e6);
 
-        // Initialize the pool and ensure that the APR is correct.
-        initialize(alice, apr, contribution);
-        assertApproxEqAbs(hyperdrive.calculateAPRFromReserves(), apr, 1e12);
+        // Initialize the pool and ensure that the spot rate is correct.
+        initialize(alice, fixedRate, contribution);
+        assertApproxEqAbs(hyperdrive.calculateSpotRate(), fixedRate, 1e12);
     }
 
     function test_nonstandard_decimals_long(
@@ -90,7 +90,7 @@ contract NonstandardDecimalsTest is HyperdriveTest {
                 bob,
                 basePaid
             );
-            uint256 fixedRate = HyperdriveUtils.calculateAPRFromRealizedPrice(
+            uint256 fixedRate = HyperdriveUtils.calculateRateFromRealizedPrice(
                 basePaid,
                 longAmount,
                 HyperdriveUtils.calculateTimeRemaining(hyperdrive, maturityTime)
@@ -186,7 +186,7 @@ contract NonstandardDecimalsTest is HyperdriveTest {
                 shortAmount
             );
             uint256 lpBasePaid = shortAmount - basePaid;
-            uint256 fixedRate = HyperdriveUtils.calculateAPRFromRealizedPrice(
+            uint256 fixedRate = HyperdriveUtils.calculateRateFromRealizedPrice(
                 lpBasePaid,
                 shortAmount,
                 HyperdriveUtils.calculateTimeRemaining(hyperdrive, maturityTime)

--- a/test/integrations/hyperdrive/RoundTripTest.t.sol
+++ b/test/integrations/hyperdrive/RoundTripTest.t.sol
@@ -16,11 +16,11 @@ contract RoundTripTest is HyperdriveTest {
     using Lib for *;
 
     function test_long_round_trip_immediately_at_checkpoint() external {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
 
         // Initialize the pool with capital.
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Get the poolInfo before opening the long.
         IHyperdrive.PoolInfo memory poolInfoBefore = hyperdrive.getPoolInfo();
@@ -44,11 +44,11 @@ contract RoundTripTest is HyperdriveTest {
     function test_long_round_trip_immediately_halfway_thru_checkpoint()
         external
     {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
 
         // Initialize the pool with capital.
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Get the poolInfo before opening the long.
         IHyperdrive.PoolInfo memory poolInfoBefore = hyperdrive.getPoolInfo();
@@ -73,11 +73,11 @@ contract RoundTripTest is HyperdriveTest {
     }
 
     function test_short_round_trip_immediately_at_checkpoint() external {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
 
         // Initialize the pool with capital.
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Get the poolInfo before opening the short.
         IHyperdrive.PoolInfo memory poolInfoBefore = hyperdrive.getPoolInfo();
@@ -101,11 +101,11 @@ contract RoundTripTest is HyperdriveTest {
     function test_short_round_trip_immediately_halfway_thru_checkpoint()
         external
     {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
 
         // Initialize the pool with capital.
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Get the poolInfo before opening the short.
         IHyperdrive.PoolInfo memory poolInfoBefore = hyperdrive.getPoolInfo();
@@ -131,14 +131,14 @@ contract RoundTripTest is HyperdriveTest {
     }
 
     function test_sandwiched_long_round_trip() external {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
         // Deploy the pool and initialize the market
         {
-            uint256 timeStretchApr = 0.05e18;
-            deploy(alice, timeStretchApr, 0, 0, 0);
+            uint256 timeStretchRate = 0.05e18;
+            deploy(alice, timeStretchRate, 0, 0, 0);
         }
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         IHyperdrive.PoolInfo memory poolInfoBefore = hyperdrive.getPoolInfo();
 
@@ -167,13 +167,13 @@ contract RoundTripTest is HyperdriveTest {
     }
 
     function test_long_multiblock_round_trip_end_of_checkpoint(
-        uint256 apr,
-        uint256 timeStretchApr,
+        uint256 fixedRate,
+        uint256 timeStretchRate,
         uint256 basePaid
     ) external {
         _test_long_multiblock_round_trip_end_of_checkpoint(
-            apr,
-            timeStretchApr,
+            fixedRate,
+            timeStretchRate,
             basePaid
         );
     }
@@ -183,12 +183,12 @@ contract RoundTripTest is HyperdriveTest {
     {
         uint256 snapshotId = vm.snapshot();
         {
-            uint256 apr = 115792089237316195423570985008687907853269984665640564039457583990320674062335;
-            uint256 timeStretchApr = 886936259672610464646559504023817532562726574141720139630650341263;
+            uint256 fixedRate = 115792089237316195423570985008687907853269984665640564039457583990320674062335;
+            uint256 timeStretchRate = 886936259672610464646559504023817532562726574141720139630650341263;
             uint256 basePaid = 65723876150308947051900890891865009457038319412461;
             _test_long_multiblock_round_trip_end_of_checkpoint(
-                apr,
-                timeStretchApr,
+                fixedRate,
+                timeStretchRate,
                 basePaid
             );
         }
@@ -198,12 +198,12 @@ contract RoundTripTest is HyperdriveTest {
         //       See issue #595
         // snapshotId = vm.snapshot();
         // {
-        //     uint256 apr = 63203229717248733662763783222570;
-        //     uint256 timeStretchApr = 3408059979187494427077136;
+        //     uint256 fixedRate = 63203229717248733662763783222570;
+        //     uint256 timeStretchRate = 3408059979187494427077136;
         //     uint256 basePaid = 57669888194155013968076316270639259357724635816572534634741412969387347636732;
         //     _test_long_multiblock_round_trip_end_of_checkpoint(
-        //         apr,
-        //         timeStretchApr,
+        //         fixedRate,
+        //         timeStretchRate,
         //         basePaid
         //     );
         // }
@@ -211,30 +211,30 @@ contract RoundTripTest is HyperdriveTest {
 
         // TODO: This test fails because the calculateMaxLong seems to be misbehaving.
         //       See issue #595
-        // uint256 apr = 115792089237316195423570985008687907853269984665640564039457583996916939587517; // 0.172756074408646686
-        // uint256 timeStretchApr = 41280540007823693914881174596677236629628473357578130920607715; // 0.059510057259928604
+        // uint256 fixedRate = 115792089237316195423570985008687907853269984665640564039457583996916939587517; // 0.172756074408646686
+        // uint256 timeStretchRate = 41280540007823693914881174596677236629628473357578130920607715; // 0.059510057259928604
         // uint256 basePaid = 3512909646876087064266547833688149281604992599057120012676367392282791491; // 3_942_239_358.711925131571174045
         // _test_long_multiblock_round_trip_end_of_checkpoint(
-        //     apr,
-        //     timeStretchApr,
+        //     fixedRate,
+        //     timeStretchRate,
         //     basePaid
         // );
     }
 
     function _test_long_multiblock_round_trip_end_of_checkpoint(
-        uint256 apr,
-        uint256 timeStretchApr,
+        uint256 fixedRate,
+        uint256 timeStretchRate,
         uint256 basePaid
     ) internal {
-        apr = apr.normalizeToRange(0.001e18, .4e18);
-        timeStretchApr = timeStretchApr.normalizeToRange(0.05e18, 0.4e18);
+        fixedRate = fixedRate.normalizeToRange(0.001e18, .4e18);
+        timeStretchRate = timeStretchRate.normalizeToRange(0.05e18, 0.4e18);
 
         // Deploy the pool and initialize the market
-        uint256 curveFee = 0.05e18; // 5% of APR
+        uint256 curveFee = 0.05e18; // 5% of fixed rate
         uint256 flatFee = 0.0005e18; // 5 bps
-        deploy(alice, timeStretchApr, curveFee, flatFee, .015e18);
+        deploy(alice, timeStretchRate, curveFee, flatFee, .015e18);
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Get the poolInfo before opening the long.
         IHyperdrive.PoolInfo memory poolInfoBefore = hyperdrive.getPoolInfo();

--- a/test/integrations/hyperdrive/SandwichTest.t.sol
+++ b/test/integrations/hyperdrive/SandwichTest.t.sol
@@ -2,7 +2,7 @@
 pragma solidity 0.8.19;
 
 import { AssetId } from "contracts/src/libraries/AssetId.sol";
-import { FixedPointMath } from "contracts/src/libraries/FixedPointMath.sol";
+import { FixedPointMath, ONE } from "contracts/src/libraries/FixedPointMath.sol";
 import { HyperdriveTest, HyperdriveUtils, IHyperdrive } from "../../utils/HyperdriveTest.sol";
 import { Lib } from "../../utils/Lib.sol";
 
@@ -11,19 +11,20 @@ contract SandwichTest is HyperdriveTest {
     using HyperdriveUtils for *;
     using Lib for *;
 
-    function test_sandwich_trades(uint8 _apr, uint64 _timeDelta) external {
-        uint256 apr = uint256(_apr) * 0.01e18;
-        uint256 timeDelta = uint256(_timeDelta);
-        vm.assume(apr >= 0.01e18 && apr <= 0.2e18);
-        vm.assume(timeDelta <= FixedPointMath.ONE_18 && timeDelta >= 0);
+    function test_sandwich_trades(
+        uint256 fixedRate,
+        uint256 timeDelta
+    ) external {
+        fixedRate = fixedRate.normalizeToRange(0.01e18, 0.2e18);
+        timeDelta = timeDelta.normalizeToRange(0, ONE);
 
         // Deploy the pool and initialize the market
         {
-            uint256 timeStretchApr = 0.02e18;
-            deploy(alice, timeStretchApr, 0, 0, 0);
+            uint256 timeStretchRate = 0.02e18;
+            deploy(alice, timeStretchRate, 0, 0, 0);
         }
         uint256 contribution = 500_000_000e18;
-        uint256 lpShares = initialize(alice, apr, contribution);
+        uint256 lpShares = initialize(alice, fixedRate, contribution);
         contribution -= 2 * hyperdrive.getPoolConfig().minimumShareReserves;
 
         // Bob opens a long.
@@ -33,9 +34,10 @@ contract SandwichTest is HyperdriveTest {
             longPaid
         );
 
-        // Some of the term passes and interest accrues at the starting APR.
+        // Some of the term passes and interest accrues at the starting fixed
+        // rate.
         uint256 timeAdvanced = POSITION_DURATION.mulDown(timeDelta);
-        advanceTime(timeAdvanced, int256(apr));
+        advanceTime(timeAdvanced, int256(fixedRate));
 
         // Celine opens a short.
         uint256 shortAmount = 200_000_000e18;
@@ -50,29 +52,36 @@ contract SandwichTest is HyperdriveTest {
         // Ensure the proceeds from the sandwich attack didn't negatively
         // impact the LP. With this in mind, they should have made at least as
         // much money as if no trades had been made and they just collected
-        // variable APR.
+        // variable rate.
         (uint256 lpProceeds, ) = removeLiquidity(alice, lpShares);
 
         // Calculate how much interest has accrued on the initial contribution
         (uint256 contributionPlusInterest, ) = HyperdriveUtils
-            .calculateCompoundInterest(contribution, int256(apr), timeAdvanced);
+            .calculateCompoundInterest(
+                contribution,
+                int256(fixedRate),
+                timeAdvanced
+            );
         assertGe(lpProceeds, contributionPlusInterest);
     }
 
-    function test_sandwich_long_trade(uint256 apr, uint256 tradeSize) external {
+    function test_sandwich_long_trade(
+        uint256 fixedRate,
+        uint256 tradeSize
+    ) external {
         // limit the fuzz testing to variableRate's less than or equal to 50%
-        apr = apr.normalizeToRange(.01e18, .5e18);
+        fixedRate = fixedRate.normalizeToRange(.01e18, .5e18);
 
         // ensure a feasible trade size
         tradeSize = tradeSize.normalizeToRange(1_000e18, 50_000_000e18 - 1e18);
 
         // Deploy the pool and initialize the market
         {
-            uint256 timeStretchApr = 0.05e18;
-            deploy(alice, timeStretchApr, 0, 0, 0);
+            uint256 timeStretchRate = 0.05e18;
+            deploy(alice, timeStretchRate, 0, 0, 0);
         }
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         uint256 shortLoss;
         // Calculate how much profit would be made from a long sandwiched by shorts
@@ -105,10 +114,10 @@ contract SandwichTest is HyperdriveTest {
 
         // Deploy the pool and initialize the market
         {
-            uint256 timeStretchApr = 0.05e18;
-            deploy(alice, timeStretchApr, 0, 0, 0);
+            uint256 timeStretchRate = 0.05e18;
+            deploy(alice, timeStretchRate, 0, 0, 0);
         }
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Calculate how much profit would be made from a simple long
         uint256 baselineProfit;
@@ -181,21 +190,19 @@ contract SandwichTest is HyperdriveTest {
         assertGe(withdrawalProceeds, contribution);
     }
 
-    // TODO: Use the normalize function to improve this test.
-    function test_sandwich_lp(uint8 _apr) external {
-        uint256 apr = uint256(_apr) * 0.01e18;
-        vm.assume(apr >= 0.01e18 && apr <= 0.2e18);
+    function test_sandwich_lp(uint256 fixedRate) external {
+        fixedRate = fixedRate.normalizeToRange(0.01e18, 0.2e18);
 
         // Deploy the pool with fees.
         {
-            uint256 timeStretchApr = 0.02e18;
+            uint256 timeStretchRate = 0.02e18;
             uint256 curveFee = 0.001e18;
-            deploy(alice, timeStretchApr, curveFee, 0, 0);
+            deploy(alice, timeStretchRate, curveFee, 0, 0);
         }
 
         // Initialize the market.
         uint256 contribution = 500_000_000e18;
-        uint256 aliceLpShares = initialize(alice, apr, contribution);
+        uint256 aliceLpShares = initialize(alice, fixedRate, contribution);
 
         // Bob opens a large long and a short.
         uint256 tradeAmount = 100_000_000e18;

--- a/test/integrations/hyperdrive/VariableInterestLongTest.t.sol
+++ b/test/integrations/hyperdrive/VariableInterestLongTest.t.sol
@@ -93,10 +93,10 @@ contract VariableInterestLongTest is HyperdriveTest {
         int256 variableInterest
     ) internal {
         // Initialize the market
-        uint256 apr = 0.05e18;
-        deploy(alice, apr, initialSharePrice, 0, 0, 0);
+        uint256 fixedRate = 0.05e18;
+        deploy(alice, fixedRate, initialSharePrice, 0, 0, 0);
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // fast forward time and accrue interest
         advanceTime(POSITION_DURATION, variableInterest);
@@ -247,10 +247,10 @@ contract VariableInterestLongTest is HyperdriveTest {
         int256 variableInterest
     ) internal {
         // Initialize the market
-        uint256 apr = 0.05e18;
-        deploy(alice, apr, initialSharePrice, 0, 0, 0);
+        uint256 fixedRate = 0.05e18;
+        deploy(alice, fixedRate, initialSharePrice, 0, 0, 0);
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // fast forward time and accrue negative interest
         advanceTime(POSITION_DURATION, preTradeVariableInterest);
@@ -413,10 +413,10 @@ contract VariableInterestLongTest is HyperdriveTest {
         int256 variableInterest
     ) internal {
         // Initialize the market
-        uint256 apr = 0.05e18;
-        deploy(alice, apr, initialSharePrice, 0, 0, 0);
+        uint256 fixedRate = 0.05e18;
+        deploy(alice, fixedRate, initialSharePrice, 0, 0, 0);
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // fast forward time and accrue negative interest
         advanceTime(POSITION_DURATION, preTradeVariableInterest);

--- a/test/integrations/hyperdrive/VariableInterestShortTest.t.sol
+++ b/test/integrations/hyperdrive/VariableInterestShortTest.t.sol
@@ -13,17 +13,18 @@ contract VariableInterestShortTest is HyperdriveTest {
     using Lib for *;
 
     function test_negative_interest_short_complete_loss(
-        int64 preTradingVariableRate,
-        int64 postTradingApr
+        int256 preTradingVariableRate,
+        int256 postTradingVariableRate
     ) external {
         // Initialize the market.
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Interest accrues for a term.
-        vm.assume(
-            preTradingVariableRate >= -0.9e18 && preTradingVariableRate <= 1e18
+        preTradingVariableRate = preTradingVariableRate.normalizeToRange(
+            -0.9e18,
+            1e18
         );
         advanceTime(POSITION_DURATION, preTradingVariableRate);
 
@@ -38,8 +39,11 @@ contract VariableInterestShortTest is HyperdriveTest {
         hyperdrive.checkpoint(HyperdriveUtils.latestCheckpoint(hyperdrive));
 
         // Interest accrues for a term.
-        vm.assume(postTradingApr >= -1e18 && postTradingApr <= 1e18);
-        advanceTime(POSITION_DURATION, postTradingApr);
+        postTradingVariableRate = postTradingVariableRate.normalizeToRange(
+            -1e18,
+            1e18
+        );
+        advanceTime(POSITION_DURATION, postTradingVariableRate);
 
         // Bob closes the short. He should receive nothing on account of the
         // negative interest.
@@ -48,18 +52,18 @@ contract VariableInterestShortTest is HyperdriveTest {
     }
 
     function test_negative_interest_short_trading_profits(
-        int64 preTradingVariableRate
+        int256 preTradingVariableRate
     ) external {
-        // Initialize the market with a very low APR.
-        uint256 apr = 0.01e18;
+        // Initialize the market with a very low fixed rate.
+        uint256 fixedRate = 0.01e18;
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Interest accrues for a term.
-        vm.assume(
-            preTradingVariableRate >= -0.5e18 && preTradingVariableRate <= 1e18
+        preTradingVariableRate = preTradingVariableRate.normalizeToRange(
+            -0.5e18,
+            1e18
         );
-
         advanceTime(POSITION_DURATION, preTradingVariableRate);
 
         // Bob opens a short.
@@ -169,10 +173,10 @@ contract VariableInterestShortTest is HyperdriveTest {
         int256 variableInterest
     ) internal {
         // Initialize the market
-        uint256 apr = 0.05e18;
-        deploy(alice, apr, initialSharePrice, 0, 0, 0);
+        uint256 fixedRate = 0.05e18;
+        deploy(alice, fixedRate, initialSharePrice, 0, 0, 0);
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // fast forward time and accrue interest
         advanceTime(POSITION_DURATION, variableInterest);
@@ -329,10 +333,10 @@ contract VariableInterestShortTest is HyperdriveTest {
         int256 variableInterest
     ) internal returns (uint256) {
         // Initialize the market
-        uint256 apr = 0.05e18;
-        deploy(alice, apr, initialSharePrice, 0, 0, 0);
+        uint256 fixedRate = 0.05e18;
+        deploy(alice, fixedRate, initialSharePrice, 0, 0, 0);
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // fast forward time and accrue interest
         advanceTime(POSITION_DURATION, preTradeVariableInterest);
@@ -492,10 +496,10 @@ contract VariableInterestShortTest is HyperdriveTest {
         int256 variableInterest
     ) internal {
         // Initialize the market
-        uint256 apr = 0.05e18;
-        deploy(alice, apr, initialSharePrice, 0, 0, 0);
+        uint256 fixedRate = 0.05e18;
+        deploy(alice, fixedRate, initialSharePrice, 0, 0, 0);
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // fast forward time and accrue negative interest
         advanceTime(POSITION_DURATION, preTradeVariableInterest);

--- a/test/mocks/MockHyperdrive.sol
+++ b/test/mocks/MockHyperdrive.sol
@@ -13,7 +13,7 @@ import { ETH } from "test/utils/Constants.sol";
 import { HyperdriveUtils } from "test/utils/HyperdriveUtils.sol";
 
 interface IMockHyperdrive {
-    function accrue(uint256 time, int256 apr) external;
+    function accrue(uint256 time, int256 rate) external;
 
     function calculateFeesOutGivenSharesIn(
         uint256 _amountIn,
@@ -115,10 +115,10 @@ contract MockHyperdrive is Hyperdrive {
 
     // Accrues compounded interest for a given number of seconds and readjusts
     // share price to reflect such compounding
-    function accrue(uint256 time, int256 apr) external {
+    function accrue(uint256 time, int256 rate) external {
         (, int256 interest) = HyperdriveUtils.calculateCompoundInterest(
             _baseToken.balanceOf(address(this)),
-            apr,
+            rate,
             time
         );
 

--- a/test/units/hyperdrive/CloseShortTest.t.sol
+++ b/test/units/hyperdrive/CloseShortTest.t.sol
@@ -8,8 +8,9 @@ import { AssetId } from "contracts/src/libraries/AssetId.sol";
 import { FixedPointMath, ONE } from "contracts/src/libraries/FixedPointMath.sol";
 import { HyperdriveMath } from "contracts/src/libraries/HyperdriveMath.sol";
 import { YieldSpaceMath } from "contracts/src/libraries/YieldSpaceMath.sol";
-import { HyperdriveTest, HyperdriveUtils } from "../../utils/HyperdriveTest.sol";
-import { Lib } from "../../utils/Lib.sol";
+import { HyperdriveTest } from "test/utils/HyperdriveTest.sol";
+import { HyperdriveUtils } from "test/utils/HyperdriveUtils.sol";
+import { Lib } from "test/utils/Lib.sol";
 
 contract CloseShortTest is HyperdriveTest {
     using FixedPointMath for uint256;
@@ -24,11 +25,11 @@ contract CloseShortTest is HyperdriveTest {
     }
 
     function test_close_short_failure_zero_amount() external {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
 
         // Initialize the pool with a large amount of capital.
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Open a short.
         uint256 bondAmount = 10e18;
@@ -42,11 +43,11 @@ contract CloseShortTest is HyperdriveTest {
     }
 
     function test_close_short_failure_invalid_amount() external {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
 
         // Initialize the pool with a large amount of capital.
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Open a short.
         uint256 bondAmount = 10e18;
@@ -60,11 +61,11 @@ contract CloseShortTest is HyperdriveTest {
     }
 
     function test_close_short_failure_invalid_timestamp() external {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
 
         // Initialize the pool with a large amount of capital.
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Open a short.
         uint256 bondAmount = 10e18;
@@ -125,11 +126,11 @@ contract CloseShortTest is HyperdriveTest {
     }
 
     function test_close_short_immediately_with_regular_amount() external {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
 
         // Initialize the pool with a large amount of capital.
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Purchase some bonds.
         uint256 bondAmount = 10e18;
@@ -161,11 +162,11 @@ contract CloseShortTest is HyperdriveTest {
     }
 
     function test_close_short_immediately_with_small_amount() external {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
 
         // Initialize the pool with a large amount of capital.
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Short some bonds.
         uint256 bondAmount = .1e18;
@@ -199,11 +200,11 @@ contract CloseShortTest is HyperdriveTest {
     // This stress tests the aggregate accounting by making the bond amount of
     // the second trade is off by 1 wei.
     function test_close_short_dust_amount() external {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
 
         // Initialize the pool with a large amount of capital.
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Open a short position.
         uint256 shortAmount = 10_000_000e18;
@@ -227,11 +228,11 @@ contract CloseShortTest is HyperdriveTest {
     function test_close_short_redeem_at_maturity_zero_variable_interest()
         external
     {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
 
         // Initialize the pool with a large amount of capital.
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Short some bonds.
         uint256 bondAmount = 10e18;
@@ -266,11 +267,11 @@ contract CloseShortTest is HyperdriveTest {
     }
 
     function test_close_short_redeem_negative_interest() external {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
 
         // Initialize the pool with a large amount of capital.
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Short some bonds.
         uint256 bondAmount = 10e18;
@@ -305,11 +306,11 @@ contract CloseShortTest is HyperdriveTest {
     }
 
     function test_close_short_redeem_negative_interest_half_term() external {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
 
         // Initialize the pool with a large amount of capital.
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Short some bonds.
         uint256 bondAmount = 10e18;
@@ -344,11 +345,11 @@ contract CloseShortTest is HyperdriveTest {
     }
 
     function test_close_short_negative_interest_at_close() external {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
 
         // Initialize the pool with a large amount of capital.
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Short some bonds.
         uint256 bondAmount = 10e18;
@@ -358,7 +359,7 @@ contract CloseShortTest is HyperdriveTest {
         advanceTime(POSITION_DURATION, -0.2e18);
 
         // A checkpoint is created to lock in the close price.
-        hyperdrive.checkpoint(HyperdriveUtils.latestCheckpoint(hyperdrive));
+        hyperdrive.checkpoint(hyperdrive.latestCheckpoint());
 
         // Another term passes and positive interest accrues.
         advanceTime(POSITION_DURATION, 0.5e18);
@@ -389,11 +390,11 @@ contract CloseShortTest is HyperdriveTest {
     }
 
     function test_close_short_max_loss() external {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
 
         // Initialize the pool with a large amount of capital.
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Short some bonds.
         uint256 bondAmount = 1000e18;
@@ -645,10 +646,7 @@ contract CloseShortTest is HyperdriveTest {
         IHyperdrive.PoolInfo memory poolInfoAfter = hyperdrive.getPoolInfo();
 
         // Verify that the other state was updated correctly.
-        uint256 timeRemaining = HyperdriveUtils.calculateTimeRemaining(
-            hyperdrive,
-            maturityTime
-        );
+        uint256 timeRemaining = hyperdrive.calculateTimeRemaining(maturityTime);
         if (wasCheckpointed) {
             assertEq(poolInfoAfter.shareReserves, poolInfoBefore.shareReserves);
             assertEq(

--- a/test/units/hyperdrive/DataProvider.t.sol
+++ b/test/units/hyperdrive/DataProvider.t.sol
@@ -9,7 +9,7 @@ import { HyperdriveStorage } from "contracts/src/HyperdriveStorage.sol";
 import { IHyperdrive } from "contracts/src/interfaces/IHyperdrive.sol";
 import { ERC20Mintable } from "contracts/test/ERC20Mintable.sol";
 import { MockHyperdrive, MockHyperdriveDataProvider } from "../../mocks/MockHyperdrive.sol";
-import { HyperdriveTest, HyperdriveUtils } from "../../utils/HyperdriveTest.sol";
+import { HyperdriveTest } from "../../utils/HyperdriveTest.sol";
 import { Lib } from "../../utils/Lib.sol";
 
 contract HyperdriveDataProviderTest is HyperdriveTest {

--- a/test/units/hyperdrive/ExtremeInputs.t.sol
+++ b/test/units/hyperdrive/ExtremeInputs.t.sol
@@ -27,23 +27,22 @@ contract ExtremeInputs is HyperdriveTest {
         (, uint256 bondAmount) = openLong(bob, baseAmount);
         IHyperdrive.PoolInfo memory poolInfoAfter = hyperdrive.getPoolInfo();
 
-        // Ensure that the ending APR is approximately 0%.
-        uint256 apr = hyperdrive.calculateAPRFromReserves();
+        // Ensure that the ending spot rate is approximately 0%.
         assertApproxEqAbs(
-            apr,
+            hyperdrive.calculateSpotRate(),
             0,
-            0.001e18, // 0% <= APR < 0.001%
-            "APR should be approximately 0%"
+            0.001e18, // 0% <= r < 0.001%
+            "spot rate should be approximately 0%"
         );
 
-        // Ensure that the bond reserves were updated to have the correct APR.
-        // Due to the way that the flat part of the trade is applied, the bond
-        // reserve updates may not exactly correspond to the amount of bonds
-        // transferred; however, the pool's APR should be identical to the APR
-        // that the bond amount transfer implies.
+        // Ensure that the bond reserves were updated to have the correct spot
+        // rate. Due to the way that the flat part of the trade is applied, the
+        // bond reserve updates may not exactly correspond to the amount of
+        // bonds transferred; however, the pool's spot rate should be identical
+        // to the spot rate that the bond amount transfer implies.
         assertApproxEqAbs(
-            hyperdrive.calculateAPRFromReserves(),
-            HyperdriveMath.calculateAPRFromReserves(
+            hyperdrive.calculateSpotRate(),
+            HyperdriveMath.calculateSpotRate(
                 poolInfoAfter.shareReserves,
                 poolInfoBefore.bondReserves - bondAmount,
                 INITIAL_SHARE_PRICE,
@@ -65,9 +64,9 @@ contract ExtremeInputs is HyperdriveTest {
         uint256 bondAmount = hyperdrive.calculateMaxShort();
 
         // Open short with max base amount
-        uint256 aprBefore = hyperdrive.calculateAPRFromReserves();
+        uint256 spotRateBefore = hyperdrive.calculateSpotRate();
         openShort(bob, bondAmount);
-        uint256 aprAfter = hyperdrive.calculateAPRFromReserves();
+        uint256 spotRateAfter = hyperdrive.calculateSpotRate();
 
         // Ensure the spot rate increased and that either the share reserves are
         // approximately equal to the minimum share reserves or the pool's
@@ -80,12 +79,13 @@ contract ExtremeInputs is HyperdriveTest {
             ) || hyperdrive.solvency() < 1e15,
             "short amount was not the max short"
         );
-        assertGt(aprAfter, aprBefore);
+        assertGt(spotRateAfter, spotRateBefore);
 
-        // Ensure that the bond reserves were updated to have the correct APR.
+        // Ensure that the bond reserves were updated to have the correct spot
+        // rate.
         assertApproxEqAbs(
-            hyperdrive.calculateAPRFromReserves(),
-            HyperdriveMath.calculateAPRFromReserves(
+            hyperdrive.calculateSpotRate(),
+            HyperdriveMath.calculateSpotRate(
                 poolInfoAfter.shareReserves,
                 poolInfoBefore.bondReserves + bondAmount,
                 INITIAL_SHARE_PRICE,
@@ -105,10 +105,11 @@ contract ExtremeInputs is HyperdriveTest {
         (, uint256 bondAmountLong) = openLong(bob, baseAmountLong);
         poolInfoAfter = hyperdrive.getPoolInfo();
 
-        // Ensure that the bond reserves were updated to have the correct APR.
+        // Ensure that the bond reserves were updated to have the correct spot
+        // rate.
         assertApproxEqAbs(
-            hyperdrive.calculateAPRFromReserves(),
-            HyperdriveMath.calculateAPRFromReserves(
+            hyperdrive.calculateSpotRate(),
+            HyperdriveMath.calculateSpotRate(
                 poolInfoAfter.shareReserves,
                 poolInfoBefore.bondReserves - bondAmountLong,
                 INITIAL_SHARE_PRICE,
@@ -130,9 +131,9 @@ contract ExtremeInputs is HyperdriveTest {
         uint256 bondAmount = hyperdrive.calculateMaxShort();
 
         // Open short with max base amount
-        uint256 aprBefore = hyperdrive.calculateAPRFromReserves();
+        uint256 spotRateBefore = hyperdrive.calculateSpotRate();
         openShort(bob, bondAmount);
-        uint256 aprAfter = hyperdrive.calculateAPRFromReserves();
+        uint256 spotRateAfter = hyperdrive.calculateSpotRate();
 
         // Ensure the spot rate increased and that either the share reserves are
         // approximately equal to the minimum share reserves or the pool's
@@ -145,16 +146,16 @@ contract ExtremeInputs is HyperdriveTest {
             ) || hyperdrive.solvency() < 1e15,
             "short amount was not the max short"
         );
-        assertGt(aprAfter, aprBefore);
+        assertGt(spotRateAfter, spotRateBefore);
 
-        // Ensure that the bond reserves were updated to have the correct APR.
-        // Due to the way that the flat part of the trade is applied, the bond
-        // reserve updates may not exactly correspond to the amount of bonds
-        // transferred; however, the pool's APR should be identical to the APR
-        // that the bond amount transfer implies.
+        // Ensure that the bond reserves were updated to have the correct spot
+        // rate. Due to the way that the flat part of the trade is applied, the
+        // bond reserve updates may not exactly correspond to the amount of
+        // bonds transferred; however, the pool's spot rate should be identical
+        // to the spot rate that the bond amount transfer implies.
         assertApproxEqAbs(
-            hyperdrive.calculateAPRFromReserves(),
-            HyperdriveMath.calculateAPRFromReserves(
+            hyperdrive.calculateSpotRate(),
+            HyperdriveMath.calculateSpotRate(
                 poolInfoAfter.shareReserves,
                 poolInfoBefore.bondReserves + bondAmount,
                 INITIAL_SHARE_PRICE,
@@ -566,11 +567,11 @@ contract ExtremeInputs is HyperdriveTest {
             // Verify that the ending bond reserves are greater than zero and
             // that the ending spot rate is the same as it was before the trade
             // is closed.
-            uint256 aprBefore = hyperdrive.calculateAPRFromReserves();
+            uint256 spotRateBefore = hyperdrive.calculateSpotRate();
             closeLong(bob, maturityTime0, longAmount);
             assertApproxEqAbs(
-                hyperdrive.calculateAPRFromReserves(),
-                aprBefore,
+                hyperdrive.calculateSpotRate(),
+                spotRateBefore,
                 tolerance
             );
             assertGt(hyperdrive.getPoolInfo().bondReserves, 0);
@@ -619,11 +620,11 @@ contract ExtremeInputs is HyperdriveTest {
             // Verify that the ending bond reserves are greater than zero and
             // that the ending spot rate is the same as it was before the trade
             // is closed.
-            uint256 aprBefore = hyperdrive.calculateAPRFromReserves();
+            uint256 spotRateBefore = hyperdrive.calculateSpotRate();
             closeShort(bob, maturityTime0, shortAmount);
             assertApproxEqAbs(
-                hyperdrive.calculateAPRFromReserves(),
-                aprBefore,
+                hyperdrive.calculateSpotRate(),
+                spotRateBefore,
                 tolerance
             );
             assertGt(hyperdrive.getPoolInfo().bondReserves, 0);
@@ -724,11 +725,11 @@ contract ExtremeInputs is HyperdriveTest {
             // Verify that the ending bond reserves are greater than zero and
             // that the ending spot rate is the same as it was before the trade
             // is closed.
-            uint256 aprBefore = hyperdrive.calculateAPRFromReserves();
+            uint256 spotRateBefore = hyperdrive.calculateSpotRate();
             closeLong(bob, maturityTime0, longAmount);
             assertApproxEqAbs(
-                hyperdrive.calculateAPRFromReserves(),
-                aprBefore,
+                hyperdrive.calculateSpotRate(),
+                spotRateBefore,
                 tolerance
             );
             assertGt(hyperdrive.getPoolInfo().bondReserves, 0);
@@ -777,11 +778,11 @@ contract ExtremeInputs is HyperdriveTest {
             // Verify that the ending bond reserves are greater than zero and
             // that the ending spot rate is the same as it was before the trade
             // is closed.
-            uint256 aprBefore = hyperdrive.calculateAPRFromReserves();
+            uint256 spotRateBefore = hyperdrive.calculateSpotRate();
             closeShort(bob, maturityTime0, shortAmount);
             assertApproxEqAbs(
-                hyperdrive.calculateAPRFromReserves(),
-                aprBefore,
+                hyperdrive.calculateSpotRate(),
+                spotRateBefore,
                 tolerance
             );
             assertGt(hyperdrive.getPoolInfo().bondReserves, 0);

--- a/test/units/hyperdrive/FeeTest.t.sol
+++ b/test/units/hyperdrive/FeeTest.t.sol
@@ -15,13 +15,11 @@ contract FeeTest is HyperdriveTest {
     using Lib for *;
 
     function test_governanceFeeAccrual() public {
-        uint256 apr = 0.05e18;
-        // Initialize the pool with a large amount of capital.
-        uint256 contribution = 500_000_000e18;
-
         // Deploy and initialize a new pool with fees.
-        deploy(alice, apr, 0.1e18, 0.1e18, 0.5e18);
-        initialize(alice, apr, contribution);
+        uint256 fixedRate = 0.05e18;
+        uint256 contribution = 500_000_000e18;
+        deploy(alice, fixedRate, 0.1e18, 0.1e18, 0.5e18);
+        initialize(alice, fixedRate, contribution);
 
         // Open a long, record the accrued fees x share price
         uint256 baseAmount = 10e18;
@@ -32,8 +30,8 @@ contract FeeTest is HyperdriveTest {
                 hyperdrive.getPoolInfo().sharePrice
             );
 
-        // Time passes and the pool accrues interest at the current apr.
-        advanceTime(POSITION_DURATION.mulDown(0.5e18), int256(apr));
+        // Time passes and the pool accrues interest at the current fixed rate.
+        advanceTime(POSITION_DURATION.mulDown(0.5e18), int256(fixedRate));
 
         // Collect fees and test that the fees received in the governance address have earned interest.
         vm.stopPrank();
@@ -57,17 +55,17 @@ contract FeeTest is HyperdriveTest {
         uint256 bondsPurchased = 0;
         // Initialize the market with 10% flat fee and 100% governance fee
         {
-            uint256 apr = 0.01e18;
+            uint256 fixedRate = 0.01e18;
             deploy(
                 alice,
-                apr,
+                fixedRate,
                 initialSharePrice,
                 curveFee,
                 flatFee,
                 governanceFee
             );
             uint256 contribution = 500_000_000e18;
-            initialize(alice, apr, contribution);
+            initialize(alice, fixedRate, contribution);
 
             // Open a long position.
             uint256 basePaid = 100_000e18;
@@ -105,10 +103,10 @@ contract FeeTest is HyperdriveTest {
         // Initialize the market with 10% flat fee and 0% governance fee
         uint256 shareReservesFlatFee = 0;
         {
-            uint256 apr = 0.01e18;
-            deploy(alice, apr, initialSharePrice, curveFee, flatFee, 0);
+            uint256 fixedRate = 0.01e18;
+            deploy(alice, fixedRate, initialSharePrice, curveFee, flatFee, 0);
             uint256 contribution = 500_000_000e18;
-            initialize(alice, apr, contribution);
+            initialize(alice, fixedRate, contribution);
 
             // Open a long position.
             uint256 basePaid = 100_000e18;
@@ -162,17 +160,17 @@ contract FeeTest is HyperdriveTest {
         uint256 spotPrice = 0;
         // Initialize the market with 10% curve fee and 100% governance fee
         {
-            uint256 apr = 0.01e18;
+            uint256 fixedRate = 0.01e18;
             deploy(
                 alice,
-                apr,
+                fixedRate,
                 initialSharePrice,
                 curveFee,
                 flatFee,
                 governanceFee
             );
             uint256 contribution = 500_000_000e18;
-            initialize(alice, apr, contribution);
+            initialize(alice, fixedRate, contribution);
 
             // Open a long position.
             uint256 basePaid = .01e18;
@@ -231,10 +229,10 @@ contract FeeTest is HyperdriveTest {
         // Initialize the market with 10% curve fee and 0% governance fee
         uint256 shareReservesCurveFee = 0;
         {
-            uint256 apr = 0.01e18;
-            deploy(alice, apr, initialSharePrice, curveFee, flatFee, 0);
+            uint256 fixedRate = 0.01e18;
+            deploy(alice, fixedRate, initialSharePrice, curveFee, flatFee, 0);
             uint256 contribution = 500_000_000e18;
-            initialize(alice, apr, contribution);
+            initialize(alice, fixedRate, contribution);
 
             // Open a long position.
             uint256 basePaid = .01e18;
@@ -290,13 +288,11 @@ contract FeeTest is HyperdriveTest {
     }
 
     function test_collectFees_long() public {
-        uint256 apr = 0.05e18;
-        // Initialize the pool with a large amount of capital.
-        uint256 contribution = 500_000_000e18;
-
         // Deploy and initialize a new pool with fees.
-        deploy(alice, apr, 0.1e18, 0.1e18, 0.5e18);
-        initialize(alice, apr, contribution);
+        uint256 fixedRate = 0.05e18;
+        uint256 contribution = 500_000_000e18;
+        deploy(alice, fixedRate, 0.1e18, 0.1e18, 0.5e18);
+        initialize(alice, fixedRate, contribution);
 
         // Ensure that the governance initially has zero balance
         uint256 governanceBalanceBefore = baseToken.balanceOf(feeCollector);
@@ -318,8 +314,9 @@ contract FeeTest is HyperdriveTest {
         ).getGovernanceFeesAccrued();
         assertGt(governanceFeesAfterOpenLong, governanceFeesBeforeOpenLong);
 
-        // Most of the term passes. The pool accrues interest at the current apr.
-        advanceTime(POSITION_DURATION.mulDown(0.5e18), int256(apr));
+        // Most of the term passes. The pool accrues interest at the current
+        // fixed rate.
+        advanceTime(POSITION_DURATION.mulDown(0.5e18), int256(fixedRate));
 
         // Bob closes his long close to maturity.
         closeLong(bob, maturityTime, bondAmount);
@@ -347,13 +344,11 @@ contract FeeTest is HyperdriveTest {
     }
 
     function test_collectFees_short() public {
-        uint256 apr = 0.05e18;
-        // Initialize the pool with a large amount of capital.
-        uint256 contribution = 500_000_000e18;
-
         // Deploy and initialize a new pool with fees.
-        deploy(alice, apr, 0.1e18, 0.1e18, 0.5e18);
-        initialize(alice, apr, contribution);
+        uint256 fixedRate = 0.05e18;
+        uint256 contribution = 500_000_000e18;
+        deploy(alice, fixedRate, 0.1e18, 0.1e18, 0.5e18);
+        initialize(alice, fixedRate, contribution);
 
         // Ensure that the governance initially has zero balance
         uint256 governanceBalanceBefore = baseToken.balanceOf(governance);
@@ -375,8 +370,9 @@ contract FeeTest is HyperdriveTest {
         ).getGovernanceFeesAccrued();
         assertGt(governanceFeesAfterOpenShort, governanceFeesBeforeOpenShort);
 
-        // Most of the term passes. The pool accrues interest at the current apr.
-        advanceTime(POSITION_DURATION.mulDown(0.5e18), int256(apr));
+        // Most of the term passes. The pool accrues interest at the current
+        // fixed rate.
+        advanceTime(POSITION_DURATION.mulDown(0.5e18), int256(fixedRate));
 
         // Redeem the bonds.
         closeShort(bob, maturityTime, bondAmount);
@@ -406,85 +402,82 @@ contract FeeTest is HyperdriveTest {
     }
 
     function test_calculateOpenLongFees() public {
-        uint256 apr = 0.05e18;
-        // Initialize the pool with a large amount of capital.
-        uint256 contribution = 500_000_000e18;
         // Deploy and initialize a new pool with fees.
-        deploy(alice, apr, 0.1e18, 0.1e18, 0.5e18);
-        initialize(alice, apr, contribution);
+        uint256 fixedRate = 0.05e18;
+        uint256 contribution = 500_000_000e18;
+        deploy(alice, fixedRate, 0.1e18, 0.1e18, 0.5e18);
+        initialize(alice, fixedRate, contribution);
 
         (uint256 curveFee, uint256 governanceCurveFee) = MockHyperdrive(
             address(hyperdrive)
         ).calculateFeesOutGivenSharesIn(
-                1 ether, // amountIn
-                0.5 ether, // spotPrice
-                1 ether //sharePrice
+                1e18, // amountIn
+                0.5e18, // spotPrice
+                1e18 //sharePrice
             );
         // total curve fee = ((1 / p) - 1) * phi_curve * c * dz
-        // ((1/.5)-1) * .1*1*1 = .1
-        assertEq(curveFee, .1 ether);
+        // ((1/0.5)-1) * 0.1*1*1 = 0.1
+        assertEq(curveFee, 0.1e18);
         // governance curve fee = total curve fee * phi_gov
-        // .1 * 0.5 = .05
-        assertEq(governanceCurveFee, .05 ether);
+        // 0.1 * 0.5 = 0.05
+        assertEq(governanceCurveFee, 0.05e18);
     }
 
     function test_calcFeesOutGivenBondsIn() public {
-        uint256 apr = 0.05e18;
-        // Initialize the pool with a large amount of capital.
-        uint256 contribution = 500_000_000e18;
         // Deploy and initialize a new pool with fees.
-        deploy(alice, apr, 0.1e18, 0.1e18, 0.5e18);
-        initialize(alice, apr, contribution);
+        uint256 fixedRate = 0.05e18;
+        uint256 contribution = 500_000_000e18;
+        deploy(alice, fixedRate, 0.1e18, 0.1e18, 0.5e18);
+        initialize(alice, fixedRate, contribution);
         (
             uint256 totalCurveFee,
             uint256 totalFlatFee,
             uint256 totalGovernanceFee
         ) = MockHyperdrive(address(hyperdrive)).calculateFeesOutGivenBondsIn(
-                1 ether, // amountIn
-                1 ether, // timeRemaining
-                0.9 ether, // spotPrice
-                1 ether // sharePrice
+                1e18, // amountIn
+                1e18, // timeRemaining
+                0.9e18, // spotPrice
+                1e18 // sharePrice
             );
         // curve fee = ((1 - p) * phi_curve * d_y * t) / c
-        // ((1-.9)*.1*1*1)/1 = .01
-        assertEq(totalCurveFee + totalFlatFee, .01 ether);
+        // ((1-0.9)*0.1*1*1)/1 = 0.01
+        assertEq(totalCurveFee + totalFlatFee, 0.01e18);
 
-        assertEq(totalGovernanceFee, .005 ether);
+        assertEq(totalGovernanceFee, 0.005e18);
 
         (totalCurveFee, totalFlatFee, totalGovernanceFee) = MockHyperdrive(
             address(hyperdrive)
         ).calculateFeesOutGivenBondsIn(
-                1 ether, // amountIn
+                1e18, // amountIn
                 0, // timeRemaining
-                0.9 ether, // spotPrice
-                1 ether // sharePrice
+                0.9e18, // spotPrice
+                1e18 // sharePrice
             );
-        assertEq(totalCurveFee + totalFlatFee, 0.1 ether);
-        assertEq(totalGovernanceFee, 0.05 ether);
+        assertEq(totalCurveFee + totalFlatFee, 0.1e18);
+        assertEq(totalGovernanceFee, 0.05e18);
     }
 
     function test_calcFeesInGivenBondsOut() public {
-        uint256 apr = 0.05e18;
-        // Initialize the pool with a large amount of capital.
-        uint256 contribution = 500_000_000e18;
         // Deploy and initialize a new pool with fees.
-        deploy(alice, apr, 0.1e18, 0.1e18, 0.5e18);
-        initialize(alice, apr, contribution);
+        uint256 fixedRate = 0.05e18;
+        uint256 contribution = 500_000_000e18;
+        deploy(alice, fixedRate, 0.1e18, 0.1e18, 0.5e18);
+        initialize(alice, fixedRate, contribution);
         (
             uint256 curveFee,
             uint256 flatFee,
             uint256 governanceCurveFee,
             uint256 governanceFlatFee
         ) = MockHyperdrive(address(hyperdrive)).calculateFeesInGivenBondsOut(
-                1 ether, // amountOut
-                1 ether, // timeRemaining
-                0.9 ether, // spotPrice
-                1 ether // sharePrice
+                1e18, // amountOut
+                1e18, // timeRemaining
+                0.9e18, // spotPrice
+                1e18 // sharePrice
             );
-        assertEq(curveFee, .01 ether);
-        assertEq(flatFee, 0 ether);
-        assertEq(governanceCurveFee, .005 ether);
-        assertEq(governanceFlatFee, 0 ether);
+        assertEq(curveFee, 0.01e18);
+        assertEq(flatFee, 0e18);
+        assertEq(governanceCurveFee, 0.005e18);
+        assertEq(governanceFlatFee, 0e18);
 
         (
             curveFee,
@@ -492,14 +485,14 @@ contract FeeTest is HyperdriveTest {
             governanceCurveFee,
             governanceFlatFee
         ) = MockHyperdrive(address(hyperdrive)).calculateFeesInGivenBondsOut(
-            1 ether, // amountOut
+            1e18, // amountOut
             0, // timeRemaining
-            0.9 ether, // spotPrice
-            1 ether // sharePrice
+            0.9e18, // spotPrice
+            1e18 // sharePrice
         );
-        assertEq(curveFee, 0 ether);
-        assertEq(flatFee, 0.1 ether);
-        assertEq(governanceCurveFee, 0 ether);
-        assertEq(governanceFlatFee, 0.05 ether);
+        assertEq(curveFee, 0e18);
+        assertEq(flatFee, 0.1e18);
+        assertEq(governanceCurveFee, 0e18);
+        assertEq(governanceFlatFee, 0.05e18);
     }
 }

--- a/test/units/hyperdrive/HyperdriveDeploy.t.sol
+++ b/test/units/hyperdrive/HyperdriveDeploy.t.sol
@@ -15,7 +15,6 @@ import { ERC20Mintable } from "contracts/test/ERC20Mintable.sol";
 import { Mock4626, ERC20 } from "../../mocks/Mock4626.sol";
 import { MockERC4626Hyperdrive } from "../../mocks/Mock4626Hyperdrive.sol";
 import { HyperdriveTest } from "../../utils/HyperdriveTest.sol";
-import { HyperdriveUtils } from "../../utils/HyperdriveUtils.sol";
 
 contract HyperdriveFactoryTest is HyperdriveTest {
     function test_hyperdrive_factory_admin_functions()

--- a/test/units/hyperdrive/RedeemWithdrawalSharesTest.t.sol
+++ b/test/units/hyperdrive/RedeemWithdrawalSharesTest.t.sol
@@ -6,12 +6,13 @@ import { IHyperdrive } from "contracts/src/interfaces/IHyperdrive.sol";
 import { AssetId } from "contracts/src/libraries/AssetId.sol";
 import { FixedPointMath } from "contracts/src/libraries/FixedPointMath.sol";
 import { HyperdriveMath } from "contracts/src/libraries/HyperdriveMath.sol";
-import { HyperdriveTest, HyperdriveUtils } from "../../utils/HyperdriveTest.sol";
-import { Lib } from "../../utils/Lib.sol";
+import { HyperdriveTest } from "test/utils/HyperdriveTest.sol";
+import { HyperdriveUtils } from "test/utils/HyperdriveUtils.sol";
+import { Lib } from "test/utils/Lib.sol";
 
 contract RedeemWithdrawalSharesTest is HyperdriveTest {
     using FixedPointMath for uint256;
-    using HyperdriveUtils for IHyperdrive;
+    using HyperdriveUtils for *;
     using Lib for *;
 
     function setUp() public override {
@@ -26,7 +27,7 @@ contract RedeemWithdrawalSharesTest is HyperdriveTest {
         uint256 lpShares = initialize(alice, 0.02e18, 500_000_000e18);
 
         // Bob opens a large short.
-        uint256 shortAmount = HyperdriveUtils.calculateMaxShort(hyperdrive);
+        uint256 shortAmount = hyperdrive.calculateMaxShort();
         (uint256 maturityTime, ) = openShort(bob, shortAmount);
 
         // Alice removes her liquidity.
@@ -56,7 +57,7 @@ contract RedeemWithdrawalSharesTest is HyperdriveTest {
         uint256 lpShares = initialize(alice, 0.02e18, 500_000_000e18);
 
         // Bob opens a large short.
-        uint256 shortAmount = HyperdriveUtils.calculateMaxShort(hyperdrive);
+        uint256 shortAmount = hyperdrive.calculateMaxShort();
         (uint256 maturityTime, ) = openShort(bob, shortAmount);
 
         // Alice removes her liquidity.
@@ -114,7 +115,7 @@ contract RedeemWithdrawalSharesTest is HyperdriveTest {
         uint256 lpShares = initialize(alice, 0.02e18, 500_000_000e18);
 
         // Bob opens a large short.
-        uint256 shortAmount = HyperdriveUtils.calculateMaxShort(hyperdrive);
+        uint256 shortAmount = hyperdrive.calculateMaxShort();
         (uint256 maturityTime, ) = openShort(bob, shortAmount);
 
         // Alice removes her liquidity.
@@ -196,7 +197,7 @@ contract RedeemWithdrawalSharesTest is HyperdriveTest {
         uint256 fixedRate = 0.02e18;
         uint256 lpShares = initialize(alice, fixedRate, contribution);
         // Bob opens a large long.
-        uint256 basePaidLong = HyperdriveUtils.calculateMaxLong(hyperdrive);
+        uint256 basePaidLong = hyperdrive.calculateMaxLong();
         (uint256 maturityTime, uint256 longAmount) = openLong(
             bob,
             basePaidLong
@@ -252,7 +253,7 @@ contract RedeemWithdrawalSharesTest is HyperdriveTest {
         uint256 lpShares = initialize(alice, 0.02e18, 500_000_000e18);
 
         // Bob opens a large short.
-        uint256 shortAmount = HyperdriveUtils.calculateMaxShort(hyperdrive);
+        uint256 shortAmount = hyperdrive.calculateMaxShort();
         (uint256 maturityTime, ) = openShort(bob, shortAmount);
 
         // Alice removes her liquidity.

--- a/test/units/hyperdrive/RemoveLiquidityTest.t.sol
+++ b/test/units/hyperdrive/RemoveLiquidityTest.t.sol
@@ -7,13 +7,13 @@ import { IHyperdrive } from "contracts/src/interfaces/IHyperdrive.sol";
 import { AssetId } from "contracts/src/libraries/AssetId.sol";
 import { FixedPointMath } from "contracts/src/libraries/FixedPointMath.sol";
 import { HyperdriveMath } from "contracts/src/libraries/HyperdriveMath.sol";
-import { MockHyperdrive } from "../../mocks/MockHyperdrive.sol";
-import { HyperdriveTest, HyperdriveUtils, IHyperdrive } from "../../utils/HyperdriveTest.sol";
-import { Lib } from "../../utils/Lib.sol";
+import { HyperdriveTest } from "test/utils/HyperdriveTest.sol";
+import { HyperdriveUtils } from "test/utils/HyperdriveUtils.sol";
+import { Lib } from "test/utils/Lib.sol";
 
 contract RemoveLiquidityTest is HyperdriveTest {
     using FixedPointMath for uint256;
-    using HyperdriveUtils for IHyperdrive;
+    using HyperdriveUtils for *;
     using Lib for *;
 
     function setUp() public override {
@@ -26,11 +26,10 @@ contract RemoveLiquidityTest is HyperdriveTest {
     /// Unit Tests ///
 
     function test_remove_liquidity_fail_zero_amount() external {
-        uint256 apr = 0.05e18;
-
         // Initialize the pool with a large amount of capital.
+        uint256 fixedRate = 0.05e18;
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Alice attempts to remove 0 lp shares.
         vm.stopPrank();
@@ -40,11 +39,10 @@ contract RemoveLiquidityTest is HyperdriveTest {
     }
 
     function test_remove_liquidity_fail_insufficient_shares() external {
-        uint256 apr = 0.05e18;
-
         // Initialize the pool with a large amount of capital.
+        uint256 fixedRate = 0.05e18;
         uint256 contribution = 500_000_000e18;
-        uint256 lpShares = initialize(alice, apr, contribution);
+        uint256 lpShares = initialize(alice, fixedRate, contribution);
 
         // Alice attempts to remove 0 lp shares.
         vm.stopPrank();
@@ -221,7 +219,7 @@ contract RemoveLiquidityTest is HyperdriveTest {
         );
 
         // Read from the state before removing liquidity.
-        uint256 fixedRateBefore = hyperdrive.calculateAPRFromReserves();
+        uint256 fixedRateBefore = hyperdrive.calculateSpotRate();
         uint256 lpTotalSupplyBefore = lpTotalSupply();
         uint256 startingPresentValue = hyperdrive.presentValue();
         uint256 expectedBaseProceeds = calculateBaseLpProceeds(
@@ -279,7 +277,7 @@ contract RemoveLiquidityTest is HyperdriveTest {
             );
 
             // Ensure that the fixed rate stayed the same after removing liquidity.
-            assertEq(hyperdrive.calculateAPRFromReserves(), fixedRateBefore);
+            assertEq(hyperdrive.calculateSpotRate(), fixedRateBefore);
 
             // Ensure that the initializer's shares were burned and that the total
             // LP supply is just the minimum share reserves.

--- a/test/units/hyperdrive/TWAPTest.sol
+++ b/test/units/hyperdrive/TWAPTest.sol
@@ -14,10 +14,10 @@ contract TWAPTest is HyperdriveTest {
     using FixedPointMath for uint256;
 
     function test_oracle_write_long() external {
-        uint256 apr = 0.05e18;
         // Initialize the pool with a large amount of capital.
+        uint256 fixedRate = 0.05e18;
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Open long
         uint256 baseAmount = 10e18;
@@ -45,7 +45,7 @@ contract TWAPTest is HyperdriveTest {
         assertEq(lastTimestamp, currentTimestamp);
 
         // Advance time
-        advanceTime(UPDATE_GAP, int256(apr));
+        advanceTime(UPDATE_GAP, int256(fixedRate));
 
         // Should record a new timestamp
         currentTimestamp = block.timestamp;
@@ -63,7 +63,7 @@ contract TWAPTest is HyperdriveTest {
         assertEq(lastTimestamp, currentTimestamp);
 
         // Should advance oracle on close timestamp after time
-        advanceTime(UPDATE_GAP, int256(apr));
+        advanceTime(UPDATE_GAP, int256(fixedRate));
         currentTimestamp = block.timestamp;
         closeLong(bob, maturityTimeSecond, bondAmountSecond);
         (head, lastTimestamp) = MockHyperdrive(address(hyperdrive))
@@ -73,10 +73,10 @@ contract TWAPTest is HyperdriveTest {
     }
 
     function test_oracle_write_short() external {
-        uint256 apr = 0.05e18;
         // Initialize the pool with a large amount of capital.
+        uint256 fixedRate = 0.05e18;
         uint256 contribution = 500_000_000e18;
-        initialize(alice, apr, contribution);
+        initialize(alice, fixedRate, contribution);
 
         // Open long
         uint256 baseAmount = 10e18;
@@ -104,7 +104,7 @@ contract TWAPTest is HyperdriveTest {
         assertEq(lastTimestamp, currentTimestamp);
 
         // Advance time
-        advanceTime(UPDATE_GAP, int256(apr));
+        advanceTime(UPDATE_GAP, int256(fixedRate));
 
         // Should record a new timestamp
         currentTimestamp = block.timestamp;
@@ -122,7 +122,7 @@ contract TWAPTest is HyperdriveTest {
         assertEq(lastTimestamp, currentTimestamp);
 
         // Should advance oracle on close timestamp after time
-        advanceTime(UPDATE_GAP, int256(apr));
+        advanceTime(UPDATE_GAP, int256(fixedRate));
         currentTimestamp = block.timestamp;
         closeShort(bob, maturityTimeSecond, bondAmountSecond);
         (head, lastTimestamp) = MockHyperdrive(address(hyperdrive))
@@ -132,10 +132,10 @@ contract TWAPTest is HyperdriveTest {
     }
 
     function recordTwelveDataPoints() internal {
-        uint256 apr = 0.05e18;
+        uint256 fixedRate = 0.05e18;
         for (uint256 i = 1; i <= 12; i++) {
             MockHyperdrive(address(hyperdrive)).recordOracle(i * 1e18);
-            advanceTime(UPDATE_GAP, int256(apr));
+            advanceTime(UPDATE_GAP, int256(fixedRate));
         }
     }
 

--- a/test/units/libraries/HyperdriveMath.t.sol
+++ b/test/units/libraries/HyperdriveMath.t.sol
@@ -18,57 +18,57 @@ contract HyperdriveMathTest is HyperdriveTest {
     using HyperdriveUtils for IHyperdrive;
     using Lib for *;
 
-    function test__calcSpotPrice() external {
+    function test__calculateSpotPrice() external {
         // NOTE: Coverage only works if I initialize the fixture in the test function
         MockHyperdriveMath hyperdriveMath = new MockHyperdriveMath();
         assertEq(
             hyperdriveMath.calculateSpotPrice(
-                1 ether, // shareReserves
-                1 ether, // bondReserves
-                1 ether, // initialSharePrice
-                1 ether // timeStretch
+                1e18, // shareReserves
+                1e18, // bondReserves
+                1e18, // initialSharePrice
+                1e18 // timeStretch
             ),
-            1 ether // 1.0 spot price
+            1e18 // 1.0 spot price
         );
 
         assertApproxEqAbs(
             hyperdriveMath.calculateSpotPrice(
-                1.1 ether, // shareReserves
-                1 ether, // bondReserves
-                1 ether, // initialSharePrice
-                1 ether // timeStretch
+                1.1e18, // shareReserves
+                1e18, // bondReserves
+                1e18, // initialSharePrice
+                1e18 // timeStretch
             ),
-            1.1 ether, // 1.1 spot price
-            1 wei
+            1.1e18, // 1.1 spot price
+            1
         );
     }
 
-    function test__calcAPRFromReserves() external {
+    function test__calcSpotRate() external {
         // NOTE: Coverage only works if I initialize the fixture in the test function
         MockHyperdriveMath hyperdriveMath = new MockHyperdriveMath();
-        // equal reserves should make 0% APR
+        // equal reserves should make 0% spot rate
         assertEq(
-            hyperdriveMath.calculateAPRFromReserves(
-                1 ether, // shareReserves
-                1 ether, // bondReserves
-                1 ether, // initialSharePrice
+            hyperdriveMath.calculateSpotRate(
+                1e18, // shareReserves
+                1e18, // bondReserves
+                1e18, // initialSharePrice
                 365 days, // positionDuration
-                1 ether // timeStretch
+                1e18 // timeStretch
             ),
-            0 // 0% APR
+            0 // 0% spot rate
         );
 
-        // target a 10% APR
+        // target a 10% spot rate
         assertApproxEqAbs(
-            hyperdriveMath.calculateAPRFromReserves(
-                1 ether, // shareReserves
-                1.1 ether, // bondReserves
-                1 ether, // initialSharePrice
+            hyperdriveMath.calculateSpotRate(
+                1e18, // shareReserves
+                1.1e18, // bondReserves
+                1e18, // initialSharePrice
                 365 days, // positionDuration
-                1 ether // timeStretch
+                1e18 // timeStretch
             ),
-            0.10 ether, // 10% APR
-            2 wei // calculation rounds up 2 wei for some reason
+            0.10e18, // 10% spot rate
+            2 // calculation rounds up 2 wei for some reason
         );
     }
 
@@ -76,10 +76,10 @@ contract HyperdriveMathTest is HyperdriveTest {
         // NOTE: Coverage only works if I initialize the fixture in the test function
         MockHyperdriveMath hyperdriveMath = new MockHyperdriveMath();
 
-        // Test .1% APR
-        uint256 shareReserves = 500_000_000 ether;
-        uint256 initialSharePrice = 1 ether;
-        uint256 apr = 0.001 ether;
+        // Test 0.1% fixed rate
+        uint256 shareReserves = 500_000_000e18;
+        uint256 initialSharePrice = 1e18;
+        uint256 fixedRate = 0.001e18;
         uint256 positionDuration = 365 days;
         uint256 timeStretch = FixedPointMath.ONE_18.divDown(
             1109.3438508425959e18
@@ -87,169 +87,170 @@ contract HyperdriveMathTest is HyperdriveTest {
         uint256 bondReserves = hyperdriveMath.calculateInitialBondReserves(
             shareReserves,
             initialSharePrice,
-            apr,
+            fixedRate,
             positionDuration,
             timeStretch
         );
-        uint256 result = hyperdriveMath.calculateAPRFromReserves(
+        uint256 result = hyperdriveMath.calculateSpotRate(
             shareReserves,
             bondReserves,
             initialSharePrice,
             positionDuration,
             timeStretch
         );
-        assertApproxEqAbs(result, apr, 20 wei);
+        assertApproxEqAbs(result, fixedRate, 20);
 
-        // Test 1% APR
-        apr = 0.01 ether;
+        // Test 1% fixed rate
+        fixedRate = 0.01e18;
         timeStretch = FixedPointMath.ONE_18.divDown(110.93438508425959e18);
         bondReserves = hyperdriveMath.calculateInitialBondReserves(
             shareReserves,
             initialSharePrice,
-            apr,
+            fixedRate,
             positionDuration,
             timeStretch
         );
-        result = hyperdriveMath.calculateAPRFromReserves(
+        result = hyperdriveMath.calculateSpotRate(
             shareReserves,
             bondReserves,
             initialSharePrice,
             positionDuration,
             timeStretch
         );
-        assertApproxEqAbs(result, apr, 1 wei);
+        assertApproxEqAbs(result, fixedRate, 1);
 
-        // Test 5% APR
-        apr = 0.05 ether;
+        // Test 5% fixed rate
+        fixedRate = 0.05e18;
         timeStretch = FixedPointMath.ONE_18.divDown(22.186877016851916266e18);
         bondReserves = hyperdriveMath.calculateInitialBondReserves(
             shareReserves,
             initialSharePrice,
-            apr,
+            fixedRate,
             positionDuration,
             timeStretch
         );
-        result = hyperdriveMath.calculateAPRFromReserves(
+        result = hyperdriveMath.calculateSpotRate(
             shareReserves,
             bondReserves,
             initialSharePrice,
             positionDuration,
             timeStretch
         );
-        assertApproxEqAbs(result, apr, 1 wei);
+        assertApproxEqAbs(result, fixedRate, 1);
 
-        // Test 25% APR
-        apr = 0.25 ether;
+        // Test 25% fixed rate
+        fixedRate = 0.25e18;
         timeStretch = FixedPointMath.ONE_18.divDown(4.437375403370384e18);
         bondReserves = hyperdriveMath.calculateInitialBondReserves(
             shareReserves,
             initialSharePrice,
-            apr,
+            fixedRate,
             positionDuration,
             timeStretch
         );
-        result = hyperdriveMath.calculateAPRFromReserves(
+        result = hyperdriveMath.calculateSpotRate(
             shareReserves,
             bondReserves,
             initialSharePrice,
             positionDuration,
             timeStretch
         );
-        assertApproxEqAbs(result, apr, 0 wei);
+        assertApproxEqAbs(result, fixedRate, 0);
 
-        // Test 50% APR
-        apr = 0.50 ether;
+        // Test 50% fixed rate
+        fixedRate = 0.50e18;
         timeStretch = FixedPointMath.ONE_18.divDown(2.218687701685192e18);
         bondReserves = hyperdriveMath.calculateInitialBondReserves(
             shareReserves,
             initialSharePrice,
-            apr,
+            fixedRate,
             positionDuration,
             timeStretch
         );
-        result = hyperdriveMath.calculateAPRFromReserves(
+        result = hyperdriveMath.calculateSpotRate(
             shareReserves,
             bondReserves,
             initialSharePrice,
             positionDuration,
             timeStretch
         );
-        assertApproxEqAbs(result, apr, 1 wei);
+        assertApproxEqAbs(result, fixedRate, 1);
 
-        // Test 100% APR
-        apr = 1 ether;
+        // Test 100% fixed rate
+        fixedRate = 1e18;
         timeStretch = FixedPointMath.ONE_18.divDown(1.109343850842596e18);
         bondReserves = hyperdriveMath.calculateInitialBondReserves(
             shareReserves,
             initialSharePrice,
-            apr,
+            fixedRate,
             positionDuration,
             timeStretch
         );
-        result = hyperdriveMath.calculateAPRFromReserves(
+        result = hyperdriveMath.calculateSpotRate(
             shareReserves,
             bondReserves,
             initialSharePrice,
             positionDuration,
             timeStretch
         );
-        assertApproxEqAbs(result, apr, 4 wei);
+        assertApproxEqAbs(result, fixedRate, 4);
     }
 
     function test__calculateOpenLong() external {
         // NOTE: Coverage only works if I initialize the fixture in the test function
         MockHyperdriveMath hyperdriveMath = new MockHyperdriveMath();
 
-        // Test open long at 1% APR, No backdating
-        uint256 shareReserves = 500_000_000 ether;
+        // Test open long at 1% fixed rate.
+        uint256 shareReserves = 500_000_000e18;
         uint256 bondReserves = 2 *
-            503_926_401.456553339958190918 ether +
+            503_926_401.456553339958190918e18 +
             shareReserves;
-        uint256 initialSharePrice = 1 ether;
+        uint256 initialSharePrice = 1e18;
         uint256 positionDuration = 365 days;
         uint256 timeStretch = FixedPointMath.ONE_18.divDown(
             110.93438508425959e18
         );
-        uint256 expectedAPR = 0.882004326279808182 ether;
-        uint256 amountIn = 50_000_000 ether;
+        uint256 expectedSpotRate = 0.882004326279808182e18;
+        uint256 amountIn = 50_000_000e18;
         uint256 bondReservesDelta = hyperdriveMath.calculateOpenLong(
             shareReserves,
             bondReserves,
             amountIn,
             timeStretch,
-            1 ether, // sharePrice
+            1e18, // sharePrice
             initialSharePrice
         );
         bondReserves -= bondReservesDelta;
         shareReserves += amountIn;
-        uint256 result = hyperdriveMath.calculateAPRFromReserves(
+        uint256 result = hyperdriveMath.calculateSpotRate(
             shareReserves,
             bondReserves,
             initialSharePrice,
             positionDuration,
             timeStretch
         );
-        // verify that the resulting APR is correct
-        assertApproxEqAbs(result, expectedAPR.divDown(100e18), 3e12);
+        // verify that the resulting spot rate is correct
+        assertApproxEqAbs(result, expectedSpotRate.divDown(100e18), 3e12);
     }
 
     function test__calculateCloseLongBeforeMaturity() external {
         // NOTE: Coverage only works if I initialize the fixture in the test function
         MockHyperdriveMath hyperdriveMath = new MockHyperdriveMath();
 
-        // Test closing the long halfway thru the term that was opened at 1% APR, No backdating
-        uint256 shareReserves = 550_000_000 ether;
+        // Test closing a long half-way through the term that was opened at 1%
+        // fixed rate.
+        uint256 shareReserves = 550_000_000e18;
         uint256 bondReserves = 2 *
-            453_456_134.637519001960754395 ether +
+            453_456_134.637519001960754395e18 +
             shareReserves;
         uint256 positionDuration = 365 days;
         uint256 normalizedTimeRemaining = 0.5e18;
         uint256 timeStretch = FixedPointMath.ONE_18.divDown(
             110.93438508425959e18
         );
-        uint256 amountIn = 503_926_401.456553339958190918 ether -
-            453_456_134.637519001960754395 ether;
-        uint256 expectedAPR = 0.9399548487105884 ether;
+        uint256 amountIn = 503_926_401.456553339958190918e18 -
+            453_456_134.637519001960754395e18;
+        uint256 expectedSpotRate = 0.9399548487105884e18;
         (
             uint256 shareReservesDelta,
             uint256 bondReservesDelta,
@@ -260,39 +261,39 @@ contract HyperdriveMathTest is HyperdriveTest {
                 amountIn,
                 normalizedTimeRemaining,
                 timeStretch,
-                1 ether,
-                1 ether
+                1e18,
+                1e18
             );
         // verify that the poolBondDelta equals the amountIn/2
         assertEq(bondReservesDelta, amountIn.mulDown(normalizedTimeRemaining));
         shareReserves -= shareReservesDelta;
         bondReserves += bondReservesDelta;
-        uint256 result = hyperdriveMath.calculateAPRFromReserves(
+        uint256 result = hyperdriveMath.calculateSpotRate(
             shareReserves,
             bondReserves,
-            1 ether,
+            1e18,
             positionDuration,
             timeStretch
         );
-        // verify that the resulting APR is correct
-        assertApproxEqAbs(result, expectedAPR.divDown(100e18), 4e12);
+        // verify that the resulting spot rate is correct
+        assertApproxEqAbs(result, expectedSpotRate.divDown(100e18), 4e12);
     }
 
     function test__calculateCloseLongAtMaturity() external {
         // NOTE: Coverage only works if I initialize the fixture in the test function
         MockHyperdriveMath hyperdriveMath = new MockHyperdriveMath();
 
-        // Test closing the long at maturity that was opened at 1% APR, No backdating
-        uint256 shareReserves = 550_000_000 ether;
+        // Test closing the long at maturity that was opened at 1% fixed rate.
+        uint256 shareReserves = 550_000_000e18;
         uint256 bondReserves = 2 *
-            453_456_134.637519001960754395 ether +
+            453_456_134.637519001960754395e18 +
             shareReserves;
         uint256 normalizedTimeRemaining = 0;
         uint256 timeStretch = FixedPointMath.ONE_18.divDown(
             110.93438508425959e18
         );
-        uint256 amountIn = 503_926_401.456553339958190918 ether -
-            453_456_134.637519001960754395 ether;
+        uint256 amountIn = 503_926_401.456553339958190918e18 -
+            453_456_134.637519001960754395e18;
         (
             uint256 shareReservesDelta,
             uint256 bondReservesDelta,
@@ -303,8 +304,8 @@ contract HyperdriveMathTest is HyperdriveTest {
                 amountIn,
                 normalizedTimeRemaining,
                 timeStretch,
-                1 ether,
-                1 ether
+                1e18,
+                1e18
             );
         // verify that the curve part is zero
         assertEq(shareReservesDelta, 0);
@@ -317,55 +318,55 @@ contract HyperdriveMathTest is HyperdriveTest {
         // NOTE: Coverage only works if I initialize the fixture in the test function
         MockHyperdriveMath hyperdriveMath = new MockHyperdriveMath();
 
-        // Test open long at 1% APR, No backdating
-        uint256 shareReserves = 500_000_000 ether;
+        // Test open long at 1% fixed rate.
+        uint256 shareReserves = 500_000_000e18;
         uint256 bondReserves = 2 *
-            503_926_401.456553339958190918 ether +
+            503_926_401.456553339958190918e18 +
             shareReserves;
         uint256 positionDuration = 365 days;
         uint256 timeStretch = FixedPointMath.ONE_18.divDown(
             110.93438508425959e18
         );
-        uint256 expectedAPR = 1.1246406058180446 ether;
+        uint256 expectedSpotRate = 1.1246406058180446e18;
         {
-            uint256 amountIn = 50_000_000 ether;
+            uint256 amountIn = 50_000_000e18;
 
             uint256 shareReservesDelta = hyperdriveMath.calculateOpenShort(
                 shareReserves,
                 bondReserves,
                 amountIn,
                 timeStretch,
-                1 ether,
-                1 ether
+                1e18,
+                1e18
             );
             bondReserves += amountIn;
             shareReserves -= shareReservesDelta;
         }
-        uint256 result = hyperdriveMath.calculateAPRFromReserves(
+        uint256 result = hyperdriveMath.calculateSpotRate(
             shareReserves,
             bondReserves,
-            1 ether,
+            1e18,
             positionDuration,
             timeStretch
         );
-        // verify that the resulting APR is correct
-        assertApproxEqAbs(result, expectedAPR.divDown(100e18), 6e12);
+        // verify that the resulting spot rate is correct
+        assertApproxEqAbs(result, expectedSpotRate.divDown(100e18), 6e12);
     }
 
     function test__calculateCloseShortAtMaturity() external {
         // NOTE: Coverage only works if I initialize the fixture in the test function
         MockHyperdriveMath hyperdriveMath = new MockHyperdriveMath();
 
-        // Test closing the long at maturity that was opened at 1% APR, No backdating
-        uint256 shareReserves = 450_000_000 ether;
+        // Test closing a long at maturity that was opened at 1% fixed rate.
+        uint256 shareReserves = 450_000_000e18;
         uint256 bondReserves = 2 *
-            554_396_668.275587677955627441 ether +
+            554_396_668.275587677955627441e18 +
             shareReserves;
         uint256 normalizedTimeRemaining = 0;
         uint256 timeStretch = FixedPointMath.ONE_18.divDown(
             110.93438508425959e18
         );
-        uint256 amountOut = 50_470_266.819034337997436523 ether;
+        uint256 amountOut = 50_470_266.819034337997436523e18;
         (
             uint256 shareReservesDelta,
             uint256 bondReservesDelta,
@@ -376,8 +377,8 @@ contract HyperdriveMathTest is HyperdriveTest {
                 amountOut,
                 normalizedTimeRemaining,
                 timeStretch,
-                1 ether,
-                1 ether
+                1e18,
+                1e18
             );
         // verify that the curve part is zero
         assertEq(shareReservesDelta, 0);
@@ -390,18 +391,18 @@ contract HyperdriveMathTest is HyperdriveTest {
         // NOTE: Coverage only works if I initialize the fixture in the test function
         MockHyperdriveMath hyperdriveMath = new MockHyperdriveMath();
 
-        // Test closing the long at maturity that was opened at 1% APR, No backdating
-        uint256 shareReserves = 450_000_000 ether;
+        // Test closing a long at maturity that was opened at 1% fixed rate.
+        uint256 shareReserves = 450_000_000e18;
         uint256 bondReserves = 2 *
-            554_396_668.275587677955627441 ether +
+            554_396_668.275587677955627441e18 +
             shareReserves;
         uint256 positionDuration = 365 days;
         uint256 normalizedTimeRemaining = 0.5e18;
         uint256 timeStretch = FixedPointMath.ONE_18.divDown(
             110.93438508425959e18
         );
-        uint256 amountOut = 50_470_266.819034337997436523 ether;
-        uint256 expectedAPR = 1.0621819862950987 ether;
+        uint256 amountOut = 50_470_266.819034337997436523e18;
+        uint256 expectedSpotRate = 1.0621819862950987e18;
         (
             uint256 shareReservesDelta,
             uint256 bondReservesDelta,
@@ -412,22 +413,22 @@ contract HyperdriveMathTest is HyperdriveTest {
                 amountOut,
                 normalizedTimeRemaining,
                 timeStretch,
-                1 ether,
-                1 ether
+                1e18,
+                1e18
             );
         // verify that the bondReservesDelta equals the amountOut/2
         assertEq(bondReservesDelta, amountOut.mulDown(normalizedTimeRemaining));
         shareReserves += shareReservesDelta;
         bondReserves -= bondReservesDelta;
-        uint256 result = hyperdriveMath.calculateAPRFromReserves(
+        uint256 result = hyperdriveMath.calculateSpotRate(
             shareReserves,
             bondReserves,
-            1 ether,
+            1e18,
             positionDuration,
             timeStretch
         );
-        // verify that the resulting APR is correct
-        assertApproxEqAbs(result, expectedAPR.divDown(100e18), 3e12);
+        // verify that the resulting spot rate is correct
+        assertApproxEqAbs(result, expectedSpotRate.divDown(100e18), 3e12);
     }
 
     function test__calculateMaxLong__matureLong(
@@ -807,10 +808,10 @@ contract HyperdriveMathTest is HyperdriveTest {
         // NOTE: Coverage only works if I initialize the fixture in the test function
         MockHyperdriveMath hyperdriveMath = new MockHyperdriveMath();
 
-        uint256 apr = 0.02e18;
+        uint256 fixedRate = 0.02e18;
         uint256 initialSharePrice = 1e18;
         uint256 positionDuration = 365 days;
-        uint256 timeStretch = HyperdriveUtils.calculateTimeStretch(apr);
+        uint256 timeStretch = HyperdriveUtils.calculateTimeStretch(fixedRate);
 
         // no open positions.
         {
@@ -821,7 +822,7 @@ contract HyperdriveMathTest is HyperdriveTest {
                     bondReserves: calculateBondReserves(
                         500_000_000e18,
                         initialSharePrice,
-                        apr,
+                        fixedRate,
                         positionDuration,
                         timeStretch
                     ),
@@ -850,7 +851,7 @@ contract HyperdriveMathTest is HyperdriveTest {
                     bondReserves: calculateBondReserves(
                         500_000_000e18,
                         initialSharePrice,
-                        apr,
+                        fixedRate,
                         positionDuration,
                         timeStretch
                     ),
@@ -888,7 +889,7 @@ contract HyperdriveMathTest is HyperdriveTest {
                     bondReserves: calculateBondReserves(
                         500_000_000e18,
                         initialSharePrice,
-                        apr,
+                        fixedRate,
                         positionDuration,
                         timeStretch
                     ),
@@ -920,7 +921,7 @@ contract HyperdriveMathTest is HyperdriveTest {
                     bondReserves: calculateBondReserves(
                         500_000_000e18,
                         initialSharePrice,
-                        apr,
+                        fixedRate,
                         positionDuration,
                         timeStretch
                     ),
@@ -958,7 +959,7 @@ contract HyperdriveMathTest is HyperdriveTest {
                     bondReserves: calculateBondReserves(
                         500_000_000e18,
                         initialSharePrice,
-                        apr,
+                        fixedRate,
                         positionDuration,
                         timeStretch
                     ),
@@ -990,7 +991,7 @@ contract HyperdriveMathTest is HyperdriveTest {
                     bondReserves: calculateBondReserves(
                         500_000_000e18,
                         initialSharePrice,
-                        apr,
+                        fixedRate,
                         positionDuration,
                         timeStretch
                     ),
@@ -1019,7 +1020,7 @@ contract HyperdriveMathTest is HyperdriveTest {
                     bondReserves: calculateBondReserves(
                         500_000_000e18,
                         initialSharePrice,
-                        apr,
+                        fixedRate,
                         positionDuration,
                         timeStretch
                     ),
@@ -1062,7 +1063,7 @@ contract HyperdriveMathTest is HyperdriveTest {
                     bondReserves: calculateBondReserves(
                         500_000_000e18,
                         initialSharePrice,
-                        apr,
+                        fixedRate,
                         positionDuration,
                         timeStretch
                     ),
@@ -1105,7 +1106,7 @@ contract HyperdriveMathTest is HyperdriveTest {
                     bondReserves: calculateBondReserves(
                         500_000_000e18,
                         initialSharePrice,
-                        apr,
+                        fixedRate,
                         positionDuration,
                         timeStretch
                     ),
@@ -1161,7 +1162,7 @@ contract HyperdriveMathTest is HyperdriveTest {
                     bondReserves: calculateBondReserves(
                         500_000_000e18,
                         initialSharePrice,
-                        apr,
+                        fixedRate,
                         positionDuration,
                         timeStretch
                     ),
@@ -1220,7 +1221,7 @@ contract HyperdriveMathTest is HyperdriveTest {
                     bondReserves: calculateBondReserves(
                         100_000e18,
                         initialSharePrice,
-                        apr,
+                        fixedRate,
                         positionDuration,
                         timeStretch
                     ),
@@ -1288,7 +1289,7 @@ contract HyperdriveMathTest is HyperdriveTest {
                     bondReserves: calculateBondReserves(
                         100_000e18,
                         initialSharePrice,
-                        apr,
+                        fixedRate,
                         positionDuration,
                         timeStretch
                     ),
@@ -1626,21 +1627,21 @@ contract HyperdriveMathTest is HyperdriveTest {
     function calculateBondReserves(
         uint256 _shareReserves,
         uint256 _initialSharePrice,
-        uint256 _apr,
+        uint256 _fixedRate,
         uint256 _positionDuration,
         uint256 _timeStretch
     ) internal pure returns (uint256 bondReserves) {
-        // Solving for (1 + r * t) ** (1 / tau) here. t is the normalized time remaining which in
-        // this case is 1. Because bonds mature after the positionDuration, we need to scale the apr
-        // to the proportion of a year of the positionDuration. tau = t / time_stretch, or just
+        // Solving for (1 + r * t) ** (1 / tau) here. t is the normalized time
+        // remaining which in this case is 1. Because bonds mature after the
+        // positionDuration, we need to scale the fixed rate to the proportion
+        // of a year of the positionDuration. tau = t / time_stretch, or just
         // 1 / time_stretch in this case.
         uint256 t = _positionDuration.divDown(365 days);
         uint256 tau = FixedPointMath.ONE_18.mulDown(_timeStretch);
-        uint256 interestFactor = (FixedPointMath.ONE_18 + _apr.mulDown(t)).pow(
-            FixedPointMath.ONE_18.divDown(tau)
-        );
+        uint256 interestFactor = (FixedPointMath.ONE_18 + _fixedRate.mulDown(t))
+            .pow(FixedPointMath.ONE_18.divDown(tau));
 
-        // bondReserves = mu * z * (1 + apr * t) ** (1 / tau)
+        // bondReserves = mu * z * (1 + r * t) ** (1 / tau)
         bondReserves = _initialSharePrice.mulDown(_shareReserves).mulDown(
             interestFactor
         );

--- a/test/utils/Lib.sol
+++ b/test/utils/Lib.sol
@@ -5,6 +5,7 @@ import { console2 } from "forge-std/console2.sol";
 import { stdMath } from "forge-std/StdMath.sol";
 import { Vm, VmSafe } from "forge-std/Vm.sol";
 
+// FIXME: Renaming this TestUtils would be cleaner IMO.
 library Lib {
     /// @dev Filters an array of longs for events that match the provided
     ///      selector.


### PR DESCRIPTION
This PR applies several stylistic changes throughout the codebase:
- `apr` => `spotRate`, `fixedRate`, or `variableRate`
- `calculateAPRFromReserves` => `calculateSpotRate`