### PR TITLE
add calc_bonds_given_shares_and_rate to rust utils

### DIFF
--- a/crates/hyperdrive-math/src/utils.rs
+++ b/crates/hyperdrive-math/src/utils.rs
@@ -22,7 +22,7 @@ pub fn get_effective_share_reserves(
 /// Calculates the bond reserves assuming that the pool has a given
 /// share reserves and fixed rate APR.
 ///
-/// r = ((1/p)-1)/t = (1-p)/(pt)
+/// r = ((1 / p) - 1) / t = (1 - p) / (pt)
 /// p = ((u * z) / y) ** t
 ///
 /// Arguments:
@@ -47,7 +47,7 @@ pub fn calculate_bonds_given_shares_and_rate(
     time_stretch: FixedPoint,
 ) -> FixedPoint {
     let annualized_time = position_duration / FixedPoint::from(U256::from(60 * 60 * 24 * 365));
-    // mu * (z - zeta) * (1 + apr * t) ** (1/tau)
+    // mu * (z - zeta) * (1 + apr * t) ** (1 / tau)
     return initial_share_price
         .mul_down(effective_share_reserves)
         .mul_down(


### PR DESCRIPTION
Adds a Rust version of the solidity `calculateInitialBondReserves` function in `HyperdriveMath.sol`.

edit: The below has been resolved with the most recent commit; there was a bug in the calculation.

----------------------------------------

I have a draft here for wrapping this in Python https://github.com/delvtech/pyperdrive/pull/16
It can't run in CI until we merge this PR and cut a new hyperdrive release. However, I can run the tests locally.

I am finding that the `calculate_bonds_given_shares_and_rate` test in pyperdrive is giving me an interesting error:
```bash
FAILED system_tests/wrapper_tests.py::test_calculate_bonds_given_shares_and_rate - pyo3_runtime.PanicException: invalid exponent
```
I think this error is popping up in the underlying rust implementation from this PR, but I don't know why.

Here's are the settings for the test:
```python
sample_pool_config = PoolConfig(
    baseToken="0x1234567890abcdef1234567890abcdef12345678",
    initialSharePrice=str(1 * 10**18),  # 1e18
    minimumShareReserves=str(1 * 10**17),  # 0.1e18
    minimumTransactionAmount=str(1 * 10**16),  # 0.001e18
    positionDuration=str(604_800),
    checkpointDuration=str(86_400),
    timeStretch=str(1 * 10**17),  # 0.1e18
    governance="0xabcdef1234567890abcdef1234567890abcdef12",
    feeCollector="0xfedcba0987654321fedcba0987654321fedcba09",
    Fees=Fees(curve=str(0), flat=str(0), governance=str(0)),
    oracleSize=str(10),
    updateGap=str(3_600),
)


sample_pool_info = PoolInfo(
    shareReserves=str(1_000_000 * 10**18),
    shareAdjustment=str(0),
    bondReserves=str(2_000_000 * 10**18),
    lpTotalSupply=str(3_000_000 * 10**18),
    sharePrice=str(1 * 10**18),
    longsOutstanding=str(0),
    longAverageMaturityTime=str(0),
    shortsOutstanding=str(0),
    shortAverageMaturityTime=str(0),
    withdrawalSharesReadyToWithdraw=str(0),
    withdrawalSharesProceeds=str(0),
    lpSharePrice=str(1 * 10**18),
    longExposure=str(0),
)
```

Following the equation for bonds:
`mu * (z - zeta) * (1 + apr * t) ** (1/tau)`

I would expect the output to be
```
y = 1 * (100000 - 0) * (1 + 3.742473403678144 * 0.02 ) ** (1/0.026677875377436178)
y = 1496383.181139349
````

Not sure why this would be invalid.