### PR TITLE
Move tokio to dev dependencies in rust crates

### DIFF
--- a/crates/fixed-point/Cargo.toml
+++ b/crates/fixed-point/Cargo.toml
@@ -9,12 +9,12 @@ edition = "2021"
 ethers = "2.0.8"
 eyre = "0.6.8"
 rand = "0.8.5"
-tokio = { version = "1", features = ["full"] }
 
 # Workspace dependencies
 fixed-point-macros = { path = "../fixed-point-macros" }
 
 [dev-dependencies]
+tokio = { version = "1", features = ["full"] }
 
 # Workspace dependencies
 hyperdrive-wrappers = { path = "../hyperdrive-wrappers" }

--- a/crates/hyperdrive-math/Cargo.toml
+++ b/crates/hyperdrive-math/Cargo.toml
@@ -15,7 +15,6 @@ path = "tests/integration_tests.rs"
 ethers = "2.0.8"
 eyre = "0.6.8"
 rand = "0.8.5"
-tokio = { version = "1", features = ["full"] }
 
 # Workspace dependencies
 fixed-point = { path = "../fixed-point" }
@@ -26,6 +25,7 @@ hyperdrive-wrappers = { path = "../hyperdrive-wrappers" }
 
 # External dependencies
 rand_chacha = "0.3.1"
+tokio = { version = "1", features = ["full"] }
 tracing = "0.1"
 tracing-test = "0.1"
 

--- a/crates/hyperdrive-wrappers/Cargo.toml
+++ b/crates/hyperdrive-wrappers/Cargo.toml
@@ -12,7 +12,6 @@ build = "build.rs"
 ethers = "2.0.8"
 eyre = "0.6.8"
 rand = "0.8.5"
-tokio = { version = "1", features = ["full"] }
 
 # Workspace dependencies
 fixed-point = { path = "../fixed-point" }
@@ -24,3 +23,4 @@ ethers = "2.0.8"
 ethers-solc = "2.0.8"
 eyre = "0.6.8"
 heck = "0.4.1"
+tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
Tokio is only used in tests and having it in the `dependencies` means these crates can't be used for the WASM wrappers since they include sys libraries that WASM doesn't support.