### PR TITLE
Fixed a bug in `get_max_long`

### DIFF
--- a/crates/hyperdrive-math/src/long.rs
+++ b/crates/hyperdrive-math/src/long.rs
@@ -165,6 +165,15 @@ impl State {
             }
         }
 
+        // Ensure that the final result is less than the absolute max and clamp
+        // to the budget.
+        if max_base_amount >= absolute_max_base_amount {
+            panic!("Reached absolute max bond amount in `get_max_long`.");
+        }
+        if max_base_amount >= budget {
+            return budget;
+        }
+
         max_base_amount
     }
 


### PR DESCRIPTION
Previously, the output of `get_max_long` wasn't clamped to the trader's budget. This PR adds the check to the end of the function.