### PR TITLE
Added `baseProceeds` to the `OpenShort` event

### DIFF
--- a/contracts/src/interfaces/IHyperdriveEvents.sol
+++ b/contracts/src/interfaces/IHyperdriveEvents.sol
@@ -63,6 +63,7 @@ interface IHyperdriveEvents is IMultiTokenEvents {
         uint256 baseAmount,
         uint256 vaultShareAmount,
         bool asBase,
+        uint256 baseProceeds,
         uint256 bondAmount
     );
 

--- a/test/units/hyperdrive/OpenShortTest.t.sol
+++ b/test/units/hyperdrive/OpenShortTest.t.sol
@@ -394,10 +394,11 @@ contract OpenShortTest is HyperdriveTest {
                 uint256 eventBaseAmount,
                 uint256 eventVaultShareAmount,
                 bool eventAsBase,
+                uint256 eventBaseProceeds,
                 uint256 eventBondAmount
             ) = abi.decode(
                     log.data,
-                    (uint256, uint256, uint256, bool, uint256)
+                    (uint256, uint256, uint256, bool, uint256, uint256)
                 );
             assertEq(eventMaturityTime, maturityTime);
             assertEq(eventBaseAmount, basePaid);
@@ -406,6 +407,7 @@ contract OpenShortTest is HyperdriveTest {
                 basePaid.divDown(hyperdrive.getPoolInfo().vaultSharePrice)
             );
             assertEq(eventAsBase, true);
+            assertEq(eventBaseProceeds, shortAmount - basePaid);
             assertEq(eventBondAmount, shortAmount);
         }
 


### PR DESCRIPTION
This PR adds the `baseProceeds` field to the `OpenShort` event. This will make it easier to calculate the pnl when traders open short positions.

h/t @wakamex