### PR TITLE
Spearbit #49: Avoided double-counting the fee in `openLong`

### DIFF
--- a/contracts/test/MockHyperdrive.sol
+++ b/contracts/test/MockHyperdrive.sol
@@ -273,7 +273,7 @@ contract MockHyperdrive is Hyperdrive, MockHyperdriveBase {
         view
         returns (
             uint256 shareReservesDelta,
-            uint256 bondProceeds,
+            uint256 bondReservesDelta,
             uint256 totalGovernanceFee
         )
     {


### PR DESCRIPTION
Addresses Spearbit Issue [#49](https://github.com/spearbit-audits/review-element-february/issues/49).