### PR TITLE
Support more options in the factory

### DIFF
--- a/.github/workflows/rust_test.yml
+++ b/.github/workflows/rust_test.yml
@@ -15,7 +15,7 @@ jobs:
 
   test:
     name: rust test
-    runs-on: ubuntu-latest-m
+    runs-on: ubuntu-latest
     needs: detect-changes
     if: needs.detect-changes.outputs.changed == 'true'
     steps:

--- a/contracts/src/deployers/HyperdriveDeployerCoordinator.sol
+++ b/contracts/src/deployers/HyperdriveDeployerCoordinator.sol
@@ -312,6 +312,63 @@ abstract contract HyperdriveDeployerCoordinator is
         return target;
     }
 
+    /// @notice Initializes a pool that was deployed by this coordinator.
+    /// @dev This function utilizes several helper functions that provide
+    ///      flexibility to implementations.
+    /// @param _deploymentId The ID of the deployment.
+    /// @param _lp The LP that is initializing the pool.
+    /// @param _contribution The amount of capital to supply. The units of this
+    ///        quantity are either base or vault shares, depending on the value
+    ///        of `_options.asBase`.
+    /// @param _apr The target APR.
+    /// @param _options The options that configure how the initialization is
+    ///        settled.
+    /// @return lpShares The initial number of LP shares created.
+    function initialize(
+        bytes32 _deploymentId,
+        address _lp,
+        uint256 _contribution,
+        uint256 _apr,
+        IHyperdrive.Options memory _options
+    ) external payable returns (uint256 lpShares) {
+        // Check that the message value is valid.
+        _checkMessageValue();
+
+        // Ensure that the instance has been fully deployed.
+        IHyperdrive hyperdrive = IHyperdrive(
+            _deployments[msg.sender][_deploymentId].hyperdrive
+        );
+        if (address(hyperdrive) == address(0)) {
+            revert IHyperdriveDeployerCoordinator.HyperdriveIsNotDeployed();
+        }
+
+        // Prepare for initialization by drawing funds from the user.
+        uint256 value = _prepareInitialize(
+            hyperdrive,
+            _lp,
+            _contribution,
+            _options
+        );
+
+        // Initialize the deployment.
+        lpShares = hyperdrive.initialize{ value: value }(
+            _contribution,
+            _apr,
+            _options
+        );
+
+        // Refund any excess ether that was sent.
+        uint256 refund = msg.value - value;
+        if (refund > 0) {
+            (bool success, ) = payable(msg.sender).call{ value: refund }("");
+            if (!success) {
+                revert IHyperdriveDeployerCoordinator.TransferFailed();
+            }
+        }
+
+        return lpShares;
+    }
+
     /// @notice Gets the deployment specified by the deployer and deployment ID.
     /// @param _deployer The deployer.
     /// @param _deploymentId The deployment ID.
@@ -322,6 +379,28 @@ abstract contract HyperdriveDeployerCoordinator is
     ) external view returns (Deployment memory) {
         return _deployments[_deployer][_deploymentId];
     }
+
+    /// @dev Prepares the coordinator for initialization by drawing funds from
+    ///      the LP, if necessary.
+    /// @param _hyperdrive The Hyperdrive instance that is being initialized.
+    /// @param _lp The LP that is initializing the pool.
+    /// @param _contribution The amount of capital to supply. The units of this
+    ///        quantity are either base or vault shares, depending on the value
+    ///        of `_options.asBase`.
+    /// @param _options The options that configure how the initialization is
+    ///        settled.
+    /// @return value The value that should be sent in the initialize
+    ///         transaction.
+    function _prepareInitialize(
+        IHyperdrive _hyperdrive,
+        address _lp,
+        uint256 _contribution,
+        IHyperdrive.Options memory _options
+    ) internal virtual returns (uint256 value);
+
+    /// @dev A yield source dependent check that prevents ether from being
+    ///      transferred to Hyperdrive instances that don't accept ether.
+    function _checkMessageValue() internal view virtual;
 
     /// @dev Checks the pool configuration to ensure that it is valid.
     /// @param _deployConfig The deploy configuration of the Hyperdrive pool.

--- a/contracts/src/interfaces/IHyperdriveDeployerCoordinator.sol
+++ b/contracts/src/interfaces/IHyperdriveDeployerCoordinator.sol
@@ -22,6 +22,14 @@ interface IHyperdriveDeployerCoordinator {
     ///         after it has already been deployed.
     error HyperdriveAlreadyDeployed();
 
+    /// @notice Thrown when a user attempts to initialize a hyperdrive contract
+    ///         before is has been deployed.
+    error HyperdriveIsNotDeployed();
+
+    /// @notice Thrown when a deployer provides an insufficient amount of base
+    ///         to initialize a payable Hyperdrive instance.
+    error InsufficientValue();
+
     /// @notice Thrown when the checkpoint duration specified is zero.
     error InvalidCheckpointDuration();
 
@@ -56,9 +64,16 @@ interface IHyperdriveDeployerCoordinator {
     ///         extra data hash.
     error MismatchedExtraData();
 
+    /// @notice Thrown when ether is sent to an instance that doesn't accept
+    ///         ether as a deposit asset.
+    error NotPayable();
+
     /// @notice Thrown when a user attempts to deploy a target contract after
     ///         it has already been deployed.
     error TargetAlreadyDeployed();
+
+    /// @notice Thrown when an ether transfer fails.
+    error TransferFailed();
 
     /// Functions ///
 
@@ -91,4 +106,24 @@ interface IHyperdriveDeployerCoordinator {
         uint256 _targetIndex,
         bytes32 _salt
     ) external returns (address);
+
+    /// @notice Initializes a pool that was deployed by this coordinator.
+    /// @dev This function utilizes several helper functions that provide
+    ///      flexibility to implementations.
+    /// @param _deploymentId The ID of the deployment.
+    /// @param _lp The LP that is initializing the pool.
+    /// @param _contribution The amount of capital to supply. The units of this
+    ///        quantity are either base or vault shares, depending on the value
+    ///        of `_options.asBase`.
+    /// @param _apr The target APR.
+    /// @param _options The options that configure how the initialization is
+    ///        settled.
+    /// @return lpShares The initial number of LP shares created.
+    function initialize(
+        bytes32 _deploymentId,
+        address _lp,
+        uint256 _contribution,
+        uint256 _apr,
+        IHyperdrive.Options memory _options
+    ) external payable returns (uint256 lpShares);
 }

--- a/contracts/src/interfaces/IHyperdriveFactory.sol
+++ b/contracts/src/interfaces/IHyperdriveFactory.sol
@@ -99,10 +99,6 @@ interface IHyperdriveFactory {
     ///         underlying list.
     error EndIndexTooLarge();
 
-    /// @notice Thrown when a deployer provides an insufficient amount of base
-    ///         to initialize a payable Hyperdrive instance.
-    error InsufficientValue();
-
     /// @notice Thrown when the checkpoint duration supplied to `deployTarget`
     ///         or `deployAndInitialize` isn't a multiple of the checkpoint
     ///         duration resolution or isn't within the range specified by the
@@ -200,6 +196,10 @@ interface IHyperdriveFactory {
     ///         time stretch APRs or doesn't satisfy the lower and upper safe
     ///         bounds implied by the fixed APR.
     error InvalidTimeStretchAPR();
+
+    /// @notice Thrown when ether is sent to the factory when `receive` is
+    ///         locked.
+    error ReceiveLocked();
 
     /// @notice Thrown when an ether transfer fails.
     error TransferFailed();

--- a/contracts/src/interfaces/ILido.sol
+++ b/contracts/src/interfaces/ILido.sol
@@ -24,7 +24,7 @@ interface ILido is IERC20 {
     /// @param _sender The owner of the tokens.
     /// @param _recipient The recipient of the tokens.
     /// @param _sharesAmount The amount of tokens that will be transferred.
-    /// @return A flag indicating whether or not the transfer succeeded.
+    /// @return The amount of stETH tokens transferred.
     function transferSharesFrom(
         address _sender,
         address _recipient,

--- a/contracts/src/internal/HyperdriveBase.sol
+++ b/contracts/src/internal/HyperdriveBase.sol
@@ -180,7 +180,7 @@ abstract contract HyperdriveBase is IHyperdriveEvents, HyperdriveStorage {
     ) internal virtual;
 
     /// @dev A yield source dependent check that prevents ether from being
-    ///         transferred to Hyperdrive instances that don't accept ether.
+    ///      transferred to Hyperdrive instances that don't accept ether.
     function _checkMessageValue() internal view virtual;
 
     /// @dev A yield source dependent check that verifies that the provided

--- a/crates/test-utils/src/chain/test_chain.rs
+++ b/crates/test-utils/src/chain/test_chain.rs
@@ -714,9 +714,12 @@ impl TestChain {
             base.mint_with_destination(client.address(), config.erc4626_hyperdrive_contribution)
                 .send()
                 .await?;
-            base.approve(factory.address(), config.erc4626_hyperdrive_contribution)
-                .send()
-                .await?;
+            base.approve(
+                erc4626_deployer_coordinator.address(),
+                config.erc4626_hyperdrive_contribution,
+            )
+            .send()
+            .await?;
             let pool_config = PoolDeployConfig {
                 fee_collector: factory.fee_collector().call().await?,
                 sweep_collector: factory.sweep_collector().call().await?,

--- a/crates/test-utils/src/chain/test_chain.rs
+++ b/crates/test-utils/src/chain/test_chain.rs
@@ -34,7 +34,7 @@ use hyperdrive_wrappers::wrappers::{
     erc4626_target4_deployer::ERC4626Target4Deployer,
     etching_vault::EtchingVault,
     hyperdrive_factory::{
-        Fees as FactoryFees, HyperdriveFactory, HyperdriveFactoryEvents, PoolDeployConfig,
+        Fees as FactoryFees, HyperdriveFactory, HyperdriveFactoryEvents, Options, PoolDeployConfig,
     },
     ierc4626_hyperdrive::IERC4626Hyperdrive,
     ihyperdrive::{Fees, PoolConfig},
@@ -810,7 +810,11 @@ impl TestChain {
                     config.erc4626_hyperdrive_contribution,
                     config.erc4626_hyperdrive_fixed_apr,
                     config.erc4626_hyperdrive_time_stretch_apr,
-                    Vec::new().into(),
+                    Options {
+                        as_base: true,
+                        destination: client.address(),
+                        extra_data: Vec::new().into(),
+                    },
                     [0x01; 32],
                 )
                 .send()
@@ -979,7 +983,11 @@ impl TestChain {
                     config.steth_hyperdrive_contribution,
                     config.steth_hyperdrive_fixed_apr,
                     config.steth_hyperdrive_time_stretch_apr,
-                    Vec::new().into(),
+                    Options {
+                        as_base: true,
+                        destination: client.address(),
+                        extra_data: Vec::new().into(),
+                    },
                     [0x02; 32],
                 )
                 .value(config.steth_hyperdrive_contribution)

--- a/test/instances/erc4626/ERC4626Hyperdrive.t.sol
+++ b/test/instances/erc4626/ERC4626Hyperdrive.t.sol
@@ -299,7 +299,7 @@ contract ERC4626HyperdriveTest is HyperdriveTest {
                 sweepCollector: factory.sweepCollector(),
                 fees: IHyperdrive.Fees(0, 0, 0, 0)
             });
-        dai.approve(address(factory), type(uint256).max);
+        dai.approve(address(deployerCoordinator), type(uint256).max);
         factory.deployTarget(
             bytes32(uint256(0xdeadbeef)),
             deployerCoordinator,
@@ -358,7 +358,11 @@ contract ERC4626HyperdriveTest is HyperdriveTest {
             contribution,
             apr,
             apr,
-            new bytes(0),
+            IHyperdrive.Options({
+                asBase: true,
+                destination: alice,
+                extraData: new bytes(0)
+            }),
             bytes32(uint256(0xdeadbabe))
         );
 
@@ -378,6 +382,7 @@ contract ERC4626HyperdriveTest is HyperdriveTest {
             alice,
             contribution,
             apr,
+            true,
             config.minimumShareReserves,
             abi.encode(address(pool)),
             0
@@ -404,7 +409,7 @@ contract ERC4626HyperdriveTest is HyperdriveTest {
                 sweepCollector: factory.sweepCollector(),
                 fees: IHyperdrive.Fees(0, 0, 0, 0)
             });
-        dai.approve(address(factory), type(uint256).max);
+        dai.approve(address(deployerCoordinator), type(uint256).max);
         factory.deployTarget(
             bytes32(uint256(0xdead)),
             deployerCoordinator,
@@ -463,7 +468,11 @@ contract ERC4626HyperdriveTest is HyperdriveTest {
             contribution,
             apr,
             apr,
-            new bytes(0),
+            IHyperdrive.Options({
+                asBase: true,
+                destination: alice,
+                extraData: new bytes(0)
+            }),
             bytes32(uint256(0xbabe))
         );
 

--- a/test/instances/erc4626/ERC4626Validation.t.sol
+++ b/test/instances/erc4626/ERC4626Validation.t.sol
@@ -121,7 +121,10 @@ abstract contract ERC4626ValidationTest is HyperdriveTest {
         factory.addDeployerCoordinator(deployerCoordinator);
 
         // Set approval to allow initial contribution to factory
-        underlyingToken.approve(address(factory), type(uint256).max);
+        underlyingToken.approve(
+            address(deployerCoordinator),
+            type(uint256).max
+        );
 
         // Deploy and set hyperdrive instance
         factory.deployTarget(
@@ -182,7 +185,11 @@ abstract contract ERC4626ValidationTest is HyperdriveTest {
             contribution,
             FIXED_RATE,
             FIXED_RATE,
-            new bytes(0),
+            IHyperdrive.Options({
+                asBase: true,
+                destination: alice,
+                extraData: new bytes(0)
+            }),
             bytes32(uint256(0xdeadbabe))
         );
 
@@ -284,7 +291,11 @@ abstract contract ERC4626ValidationTest is HyperdriveTest {
             contribution,
             FIXED_RATE,
             FIXED_RATE,
-            new bytes(0),
+            IHyperdrive.Options({
+                asBase: true,
+                destination: alice,
+                extraData: new bytes(0)
+            }),
             bytes32(uint256(0xfade))
         );
 
@@ -305,6 +316,7 @@ abstract contract ERC4626ValidationTest is HyperdriveTest {
             alice,
             contribution,
             FIXED_RATE,
+            true,
             config.minimumShareReserves,
             extraData,
             1e5

--- a/test/instances/erc4626/ERC4626Validation.t.sol
+++ b/test/instances/erc4626/ERC4626Validation.t.sol
@@ -208,7 +208,7 @@ abstract contract ERC4626ValidationTest is HyperdriveTest {
         int256 variableRate
     ) public virtual;
 
-    function test_deployAndInitialize() external {
+    function test_deployAndInitialize_asBase() external {
         vm.startPrank(alice);
 
         IHyperdrive.PoolDeployConfig memory config = testDeployConfig(
@@ -229,7 +229,10 @@ abstract contract ERC4626ValidationTest is HyperdriveTest {
             .getPoolConfig()
             .minimumShareReserves;
         uint256 contribution = 10_000 * 10 ** decimals;
-        underlyingToken.approve(address(factory), type(uint256).max);
+        underlyingToken.approve(
+            address(deployerCoordinator),
+            type(uint256).max
+        );
 
         // Deploy a new hyperdrive instance
         bytes memory extraData = abi.encode(address(token));

--- a/test/instances/erc4626/UsdcERC4626.t.sol
+++ b/test/instances/erc4626/UsdcERC4626.t.sol
@@ -130,7 +130,10 @@ contract UsdcERC4626 is ERC4626ValidationTest {
         factory.addDeployerCoordinator(deployerCoordinator);
 
         // Set approval to allow initial contribution to factory.
-        underlyingToken.approve(address(factory), type(uint256).max);
+        underlyingToken.approve(
+            address(deployerCoordinator),
+            type(uint256).max
+        );
 
         // Deploy and set hyperdrive instance.
         bytes memory extraData = abi.encode(address(token));
@@ -192,7 +195,11 @@ contract UsdcERC4626 is ERC4626ValidationTest {
             contribution,
             FIXED_RATE,
             FIXED_RATE,
-            new bytes(0),
+            IHyperdrive.Options({
+                asBase: true,
+                destination: alice,
+                extraData: new bytes(0)
+            }),
             bytes32(uint256(0xdeadfade))
         );
 

--- a/test/instances/steth/StETHHyperdrive.t.sol
+++ b/test/instances/steth/StETHHyperdrive.t.sol
@@ -182,7 +182,11 @@ contract StETHHyperdriveTest is HyperdriveTest {
             contribution,
             FIXED_RATE,
             FIXED_RATE,
-            new bytes(0),
+            IHyperdrive.Options({
+                asBase: true,
+                destination: alice,
+                extraData: new bytes(0)
+            }),
             bytes32(uint256(0xdeadbabe))
         );
 
@@ -214,7 +218,7 @@ contract StETHHyperdriveTest is HyperdriveTest {
 
     /// Deploy and Initialize ///
 
-    function test__steth__deployAndInitialize() external {
+    function test__steth__deployAndInitialize__asBase() external {
         // Deploy and Initialize the stETH hyperdrive instance. Excess ether is
         // sent, and should be returned to the sender.
         vm.stopPrank();
@@ -299,7 +303,11 @@ contract StETHHyperdriveTest is HyperdriveTest {
             contribution,
             FIXED_RATE,
             FIXED_RATE,
-            new bytes(0),
+            IHyperdrive.Options({
+                asBase: true,
+                destination: bob,
+                extraData: new bytes(0)
+            }),
             bytes32(uint256(0xdeadfade))
         );
         assertEq(address(bob).balance, bobBalanceBefore - contribution);
@@ -340,6 +348,146 @@ contract StETHHyperdriveTest is HyperdriveTest {
             bob,
             contribution,
             FIXED_RATE,
+            true,
+            config.minimumShareReserves,
+            new bytes(0),
+            // NOTE: Tolerance since stETH uses mulDivDown for share calculations.
+            1e5
+        );
+    }
+
+    function test__steth__deployAndInitialize__asShares() external {
+        // Deploy and Initialize the stETH hyperdrive instance. Excess ether is
+        // sent, and should be returned to the sender.
+        vm.stopPrank();
+        vm.startPrank(bob);
+        uint256 contributionShares = 5_000e18;
+        uint256 contribution = LIDO.getPooledEthByShares(contributionShares);
+        LIDO.submit{ value: contribution }(address(0));
+        LIDO.approve(deployerCoordinator, contribution);
+        IHyperdrive.PoolDeployConfig memory config = IHyperdrive
+            .PoolDeployConfig({
+                baseToken: IERC20(ETH),
+                governance: factory.hyperdriveGovernance(),
+                feeCollector: factory.feeCollector(),
+                sweepCollector: factory.sweepCollector(),
+                linkerFactory: factory.linkerFactory(),
+                linkerCodeHash: factory.linkerCodeHash(),
+                minimumShareReserves: 1e15,
+                minimumTransactionAmount: 1e15,
+                positionDuration: POSITION_DURATION,
+                checkpointDuration: CHECKPOINT_DURATION,
+                timeStretch: 0,
+                fees: IHyperdrive.Fees({
+                    curve: 0,
+                    flat: 0,
+                    governanceLP: 0,
+                    governanceZombie: 0
+                })
+            });
+        factory.deployTarget(
+            bytes32(uint256(0xbeefbabe)),
+            deployerCoordinator,
+            config,
+            new bytes(0),
+            FIXED_RATE,
+            FIXED_RATE,
+            0,
+            bytes32(uint256(0xdeadfade))
+        );
+        factory.deployTarget(
+            bytes32(uint256(0xbeefbabe)),
+            deployerCoordinator,
+            config,
+            new bytes(0),
+            FIXED_RATE,
+            FIXED_RATE,
+            1,
+            bytes32(uint256(0xdeadfade))
+        );
+        factory.deployTarget(
+            bytes32(uint256(0xbeefbabe)),
+            deployerCoordinator,
+            config,
+            new bytes(0),
+            FIXED_RATE,
+            FIXED_RATE,
+            2,
+            bytes32(uint256(0xdeadfade))
+        );
+        factory.deployTarget(
+            bytes32(uint256(0xbeefbabe)),
+            deployerCoordinator,
+            config,
+            new bytes(0),
+            FIXED_RATE,
+            FIXED_RATE,
+            3,
+            bytes32(uint256(0xdeadfade))
+        );
+        factory.deployTarget(
+            bytes32(uint256(0xbeefbabe)),
+            deployerCoordinator,
+            config,
+            new bytes(0),
+            FIXED_RATE,
+            FIXED_RATE,
+            4,
+            bytes32(uint256(0xdeadfade))
+        );
+        hyperdrive = factory.deployAndInitialize(
+            bytes32(uint256(0xbeefbabe)),
+            address(deployerCoordinator),
+            config,
+            new bytes(0),
+            contributionShares,
+            FIXED_RATE,
+            FIXED_RATE,
+            IHyperdrive.Options({
+                asBase: false,
+                destination: bob,
+                extraData: new bytes(0)
+            }),
+            bytes32(uint256(0xdeadfade))
+        );
+
+        // Ensure that the decimals are set correctly.
+        assertEq(hyperdrive.decimals(), 18);
+
+        // Ensure that Bob received the correct amount of LP tokens. He should
+        // receive LP shares totaling the amount of shares that he contributed
+        // minus the shares set aside for the minimum share reserves and the
+        // zero address's initial LP contribution.
+        assertApproxEqAbs(
+            hyperdrive.balanceOf(AssetId._LP_ASSET_ID, bob),
+            contribution.divDown(
+                hyperdrive.getPoolConfig().initialVaultSharePrice
+            ) - 2 * hyperdrive.getPoolConfig().minimumShareReserves,
+            1e5
+        );
+
+        // Ensure that the share reserves and LP total supply are equal and correct.
+        assertApproxEqAbs(
+            hyperdrive.getPoolInfo().shareReserves,
+            contribution.mulDivDown(
+                LIDO.getTotalShares(),
+                LIDO.getTotalPooledEther()
+            ),
+            1
+        );
+        assertEq(
+            hyperdrive.getPoolInfo().lpTotalSupply,
+            hyperdrive.getPoolInfo().shareReserves - config.minimumShareReserves
+        );
+
+        // Verify that the correct events were emitted.
+        verifyFactoryEvents(
+            deployerCoordinator,
+            hyperdrive,
+            bob,
+            contributionShares,
+            FIXED_RATE,
+            false,
             config.minimumShareReserves,
             new bytes(0),
             // NOTE: Tolerance since stETH uses mulDivDown for share calculations.

--- a/test/integrations/factory/HyperdriveFactory.t.sol
+++ b/test/integrations/factory/HyperdriveFactory.t.sol
@@ -1547,7 +1547,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.02e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
         }
@@ -1572,7 +1576,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.02e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.checkpointDuration = oldCheckpointDuration;
@@ -1598,7 +1606,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.02e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.checkpointDuration = oldCheckpointDuration;
@@ -1622,7 +1634,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.02e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.checkpointDuration = oldCheckpointDuration;
@@ -1648,7 +1664,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.02e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.positionDuration = oldPositionDuration;
@@ -1674,7 +1694,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.02e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.positionDuration = oldPositionDuration;
@@ -1698,7 +1722,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.02e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.positionDuration = oldPositionDuration;
@@ -1719,7 +1747,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 fixedAPR,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
         }
@@ -1739,7 +1771,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 fixedAPR,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
         }
@@ -1761,7 +1797,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.001e18,
                 0.004e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
         }
@@ -1780,7 +1820,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.02e18,
                 0.006e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
         }
@@ -1802,7 +1846,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.02e18,
                 0.019e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
         }
@@ -1824,7 +1872,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.003e18,
                 0.011e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
         }
@@ -1843,7 +1895,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.012e18,
                 0.025e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
         }
@@ -1865,7 +1921,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.3e18,
                 0.31e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
         }
@@ -1886,7 +1946,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.05e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.fees.curve = oldCurveFee;
@@ -1908,7 +1972,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.05e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.fees.curve = oldCurveFee;
@@ -1930,7 +1998,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.05e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.fees.flat = oldFlatFee;
@@ -1952,7 +2024,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.05e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.fees.flat = oldFlatFee;
@@ -1974,7 +2050,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.05e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.fees.governanceLP = oldGovernanceLPFee;
@@ -1996,7 +2076,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.05e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.fees.governanceLP = oldGovernanceLPFee;
@@ -2020,7 +2104,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.05e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.fees.governanceZombie = oldGovernanceZombieFee;
@@ -2044,7 +2132,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.05e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.fees.governanceZombie = oldGovernanceZombieFee;
@@ -2066,7 +2158,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.05e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.linkerFactory = oldLinkerFactory;
@@ -2088,7 +2184,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.05e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.linkerCodeHash = oldLinkerCodeHash;
@@ -2110,7 +2210,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.05e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.feeCollector = oldFeeCollector;
@@ -2132,7 +2236,11 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.05e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.sweepCollector = oldSweepCollector;
@@ -2154,29 +2262,14 @@ contract HyperdriveFactoryTest is HyperdriveTest {
                 10_000e18,
                 0.05e18,
                 0.05e18,
-                new bytes(0),
+                IHyperdrive.Options({
+                    asBase: true,
+                    destination: bob,
+                    extraData: new bytes(0)
+                }),
                 bytes32(uint256(0xdeadbabe))
             );
             config.governance = oldGovernance;
-        }
-
-        // Ensure that an instance can't be deployed with an invalid message
-        // value.
-        {
-            vm.stopPrank();
-            vm.startPrank(bob);
-            vm.expectRevert(IHyperdriveFactory.InsufficientValue.selector);
-            factory.deployAndInitialize{ value: 5_000e18 }(
-                bytes32(uint256(0xdeadbeef)),
-                deployerCoordinator,
-                config,
-                extraData,
-                10_000e18,
-                0.05e18,
-                0.05e18,
-                new bytes(0),
-                bytes32(uint256(0xdeadbabe))
-            );
         }
     }
 }
@@ -2325,14 +2418,14 @@ contract HyperdriveFactoryBaseTest is HyperdriveTest {
     }
 
     function _deployInstance(
-        address deployerUser,
+        address deployer,
         address pool
     ) internal returns (IHyperdrive) {
-        deal(address(dai), deployerUser, CONTRIBUTION);
+        deal(address(dai), deployer, CONTRIBUTION);
 
-        vm.startPrank(deployerUser);
+        vm.startPrank(deployer);
 
-        dai.approve(address(factory), CONTRIBUTION);
+        dai.approve(address(deployerCoordinator), CONTRIBUTION);
 
         deploymentId = keccak256(abi.encode(deploymentId));
         salt = keccak256(abi.encode(salt));
@@ -2395,7 +2488,11 @@ contract HyperdriveFactoryBaseTest is HyperdriveTest {
             CONTRIBUTION,
             APR,
             APR,
-            new bytes(0),
+            IHyperdrive.Options({
+                asBase: true,
+                destination: deployer,
+                extraData: new bytes(0)
+            }),
             salt
         );
 
@@ -2438,12 +2535,17 @@ contract ERC4626FactoryMultiDeployTest is HyperdriveFactoryBaseTest {
 
         // 1. Charlie deploys factory with yDAI as yield source, hyperdrive deployer 1.
 
-        dai.approve(address(factory), CONTRIBUTION);
+        dai.approve(address(deployerCoordinator), CONTRIBUTION);
 
         assertEq(dai.balanceOf(charlie), CONTRIBUTION);
         assertEq(dai.balanceOf(address(pool1)), 0);
 
         bytes memory extraData = abi.encode(address(pool1));
+        IHyperdrive.Options memory options = IHyperdrive.Options({
+            asBase: true,
+            destination: charlie,
+            extraData: new bytes(0)
+        });
         factory.deployTarget(
             bytes32(uint256(0xdeadbeef)),
             deployerCoordinator,
@@ -2502,7 +2604,7 @@ contract ERC4626FactoryMultiDeployTest is HyperdriveFactoryBaseTest {
             CONTRIBUTION,
             APR,
             APR,
-            new bytes(0),
+            options,
             bytes32(uint256(0xdeadbabe))
         );
 
@@ -2525,6 +2627,7 @@ contract ERC4626FactoryMultiDeployTest is HyperdriveFactoryBaseTest {
             charlie,
             CONTRIBUTION,
             APR,
+            true,
             config.minimumShareReserves,
             extraData,
             0
@@ -2541,7 +2644,7 @@ contract ERC4626FactoryMultiDeployTest is HyperdriveFactoryBaseTest {
 
         deal(address(dai), charlie, CONTRIBUTION);
 
-        dai.approve(address(factory), CONTRIBUTION);
+        dai.approve(address(deployerCoordinator1), CONTRIBUTION);
 
         extraData = abi.encode(address(pool2));
         factory.deployTarget(
@@ -2602,7 +2705,7 @@ contract ERC4626FactoryMultiDeployTest is HyperdriveFactoryBaseTest {
             CONTRIBUTION,
             APR,
             APR,
-            new bytes(0),
+            options,
             bytes32(uint256(0xbabe))
         );
 
@@ -2625,6 +2728,7 @@ contract ERC4626FactoryMultiDeployTest is HyperdriveFactoryBaseTest {
             charlie,
             CONTRIBUTION,
             APR,
+            true,
             config.minimumShareReserves,
             extraData,
             0
@@ -2645,12 +2749,13 @@ contract ERC4626FactoryMultiDeployTest is HyperdriveFactoryBaseTest {
 
         vm.startPrank(dan);
 
-        dai.approve(address(factory), CONTRIBUTION);
+        dai.approve(address(deployerCoordinator), CONTRIBUTION);
 
         assertEq(dai.balanceOf(dan), CONTRIBUTION);
         assertEq(dai.balanceOf(address(pool2)), CONTRIBUTION); // From Charlie
 
         extraData = abi.encode(address(pool2));
+        options.destination = dan;
         factory.deployTarget(
             bytes32(uint256(0xbeef)),
             deployerCoordinator,
@@ -2709,7 +2814,7 @@ contract ERC4626FactoryMultiDeployTest is HyperdriveFactoryBaseTest {
             CONTRIBUTION,
             APR,
             APR,
-            new bytes(0),
+            options,
             bytes32(uint256(0xdead))
         );
 
@@ -2732,6 +2837,7 @@ contract ERC4626FactoryMultiDeployTest is HyperdriveFactoryBaseTest {
             dan,
             CONTRIBUTION,
             APR,
+            true,
             config.minimumShareReserves,
             extraData,
             0

--- a/test/utils/HyperdriveTest.sol
+++ b/test/utils/HyperdriveTest.sol
@@ -919,6 +919,7 @@ contract HyperdriveTest is IHyperdriveEvents, BaseTest {
         address deployer,
         uint256 contribution,
         uint256 apr,
+        bool asBase,
         uint256 minimumShareReserves,
         bytes memory expectedExtraData,
         uint256 tolerance
@@ -1009,6 +1010,7 @@ contract HyperdriveTest is IHyperdriveEvents, BaseTest {
             );
 
             // Verify the event data.
+            IHyperdrive hyperdrive_ = _hyperdrive;
             (
                 uint256 eventLpAmount,
                 uint256 eventBaseAmount,
@@ -1020,23 +1022,37 @@ contract HyperdriveTest is IHyperdriveEvents, BaseTest {
                     (uint256, uint256, uint256, bool, uint256)
                 );
             uint256 contribution_ = contribution;
-            IHyperdrive hyperdrive_ = _hyperdrive;
-            assertApproxEqAbs(
-                eventLpAmount,
-                contribution_.divDown(
-                    hyperdrive_.getPoolConfig().initialVaultSharePrice
-                ) - 2 * minimumShareReserves,
-                tolerance
-            );
-            assertEq(eventBaseAmount, contribution_);
-            assertApproxEqAbs(
-                eventShareAmount,
-                contribution_.divDown(
-                    hyperdrive_.getPoolInfo().vaultSharePrice
-                ),
-                1e5
-            );
-            assertEq(eventAsBase, true);
+            if (asBase) {
+                assertApproxEqAbs(
+                    eventLpAmount,
+                    contribution_.divDown(
+                        hyperdrive_.getPoolConfig().initialVaultSharePrice
+                    ) - 2 * minimumShareReserves,
+                    tolerance
+                );
+                assertEq(eventBaseAmount, contribution_);
+                assertApproxEqAbs(
+                    eventShareAmount,
+                    contribution_.divDown(
+                        hyperdrive_.getPoolConfig().initialVaultSharePrice
+                    ),
+                    1e5
+                );
+            } else {
+                assertApproxEqAbs(
+                    eventLpAmount,
+                    contribution_ - 2 * minimumShareReserves,
+                    tolerance
+                );
+                assertEq(
+                    eventBaseAmount,
+                    contribution_.mulDown(
+                        hyperdrive_.getPoolInfo().vaultSharePrice
+                    )
+                );
+                assertApproxEqAbs(eventShareAmount, contribution_, 1e5);
+            }
+            assertEq(eventAsBase, asBase);
             assertEq(eventApr, apr);
         }
     }


### PR DESCRIPTION
This PR makes it possible for the HyperdriveFactory to initialize with either `options.asBase = true` or `options.asBase = false`. Since it is cumbersome for the factory to handle vault shares (think about the case of Lido shares for an example), this PR moves the initialization logic into the deployer coordinators since deployer coordinators are tightly coupled to yield sources and can include bespoke logic.