### PR TITLE
Calculate `normalized_time_remaining` from timestamps

### DIFF
--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -143,7 +143,11 @@ impl State {
     }
 
     /// Gets the normalized time remaining
-    fn calculate_time_remaining(&self, maturity_time: U256, current_time: U256) -> FixedPoint {
+    fn calculate_normalized_time_remaining(
+        &self,
+        maturity_time: U256,
+        current_time: U256,
+    ) -> FixedPoint {
         let latest_checkpoint = self.to_checkpoint(current_time);
         let time_remaining = if maturity_time > latest_checkpoint {
             FixedPoint::from(maturity_time - latest_checkpoint)

--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -142,6 +142,21 @@ impl State {
         }
     }
 
+    /// Gets the normalized time remaining
+    fn calculate_time_remaining(&self, maturity_time: U256, current_time: U256) -> FixedPoint {
+        let latest_checkpoint = self.to_checkpoint(current_time);
+        let time_remaining = if maturity_time > latest_checkpoint {
+            FixedPoint::from(maturity_time - latest_checkpoint)
+        } else {
+            fixed!(0)
+        };
+
+        // NOTE: Round down to underestimate the time remaining.
+        let time_remaining = time_remaining.div_down(self.position_duration());
+
+        time_remaining
+    }
+
     /// Config ///
 
     fn position_duration(&self) -> FixedPoint {

--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -258,9 +258,10 @@ impl YieldSpace for State {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use eyre::Result;
     use rand::thread_rng;
+
+    use super::*;
 
     #[tokio::test]
     async fn test_calculate_normalized_time_remaining() -> Result<()> {

--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -270,9 +270,9 @@ mod tests {
 
         // Set a snapshot for the values used for calculating normalized time
         // remaining
-        state.config.position_duration = fixed!(0.000000000028209717e18).into();
-        state.config.checkpoint_duration = fixed!(0.000000000000043394e18).into();
-        let expected_time_remaining = fixed!(0.000003544877816392e18);
+        state.config.position_duration = fixed!(28209717).into();
+        state.config.checkpoint_duration = fixed!(43394).into();
+        let expected_time_remaining = fixed!(3544877816392);
 
         let maturity_time = U256::from(100);
         let current_time = U256::from(90);

--- a/crates/hyperdrive-math/src/long/close.rs
+++ b/crates/hyperdrive-math/src/long/close.rs
@@ -12,7 +12,7 @@ impl State {
         current_time: U256,
     ) -> FixedPoint {
         let bond_amount = bond_amount.into();
-        let normalized_time_remaining = self.calculate_time_remaining(maturity_time, current_time);
+        let normalized_time_remaining = self.calculate_normalized_time_remaining(maturity_time, current_time);
 
         // Calculate the flat part of the trade
         let flat = bond_amount.mul_div_down(
@@ -71,7 +71,7 @@ mod tests {
             let maturity_time = state.checkpoint_duration();
             let current_time = rng.gen_range(fixed!(0)..=maturity_time);
             let normalized_time_remaining =
-                state.calculate_time_remaining(maturity_time.into(), current_time.into());
+                state.calculate_normalized_time_remaining(maturity_time.into(), current_time.into());
             let actual = panic::catch_unwind(|| {
                 state.calculate_close_long_flat_plus_curve(
                     in_,

--- a/crates/hyperdrive-math/src/long/close.rs
+++ b/crates/hyperdrive-math/src/long/close.rs
@@ -12,7 +12,8 @@ impl State {
         current_time: U256,
     ) -> FixedPoint {
         let bond_amount = bond_amount.into();
-        let normalized_time_remaining = self.calculate_normalized_time_remaining(maturity_time, current_time);
+        let normalized_time_remaining =
+            self.calculate_normalized_time_remaining(maturity_time, current_time);
 
         // Calculate the flat part of the trade
         let flat = bond_amount.mul_div_down(
@@ -70,8 +71,8 @@ mod tests {
             let in_ = rng.gen_range(fixed!(0)..=state.effective_share_reserves());
             let maturity_time = state.checkpoint_duration();
             let current_time = rng.gen_range(fixed!(0)..=maturity_time);
-            let normalized_time_remaining =
-                state.calculate_normalized_time_remaining(maturity_time.into(), current_time.into());
+            let normalized_time_remaining = state
+                .calculate_normalized_time_remaining(maturity_time.into(), current_time.into());
             let actual = panic::catch_unwind(|| {
                 state.calculate_close_long_flat_plus_curve(
                     in_,

--- a/crates/hyperdrive-math/src/long/fees.rs
+++ b/crates/hyperdrive-math/src/long/fees.rs
@@ -37,7 +37,7 @@ impl State {
         maturity_time: U256,
         current_time: U256,
     ) -> FixedPoint {
-        let normalized_time_remaining = self.calculate_time_remaining(maturity_time, current_time);
+        let normalized_time_remaining = self.calculate_normalized_time_remaining(maturity_time, current_time);
         // curve_fee = ((1 - p) * phi_curve * d_y * t) / c
         self.curve_fee()
             * (fixed!(1e18) - self.get_spot_price())
@@ -52,7 +52,7 @@ impl State {
         maturity_time: U256,
         current_time: U256,
     ) -> FixedPoint {
-        let normalized_time_remaining = self.calculate_time_remaining(maturity_time, current_time);
+        let normalized_time_remaining = self.calculate_normalized_time_remaining(maturity_time, current_time);
         // flat_fee = (d_y * (1 - t) * phi_flat) / c
         bond_amount.mul_div_down(
             fixed!(1e18) - normalized_time_remaining,

--- a/crates/hyperdrive-math/src/long/fees.rs
+++ b/crates/hyperdrive-math/src/long/fees.rs
@@ -1,5 +1,8 @@
+
+use ethers::types::U256;
 use fixed_point::FixedPoint;
 use fixed_point_macros::fixed;
+
 
 use crate::State;
 
@@ -33,8 +36,8 @@ impl State {
     pub fn close_long_curve_fee(
         &self,
         bond_amount: FixedPoint,
-        maturity_time: FixedPoint,
-        current_time: FixedPoint
+        maturity_time: U256,
+        current_time: U256 
     ) -> FixedPoint {
         let normalized_time_remaining = self.calculate_time_remaining(maturity_time, current_time);
         // curve_fee = ((1 - p) * phi_curve * d_y * t) / c
@@ -48,8 +51,8 @@ impl State {
     pub fn close_long_flat_fee(
         &self,
         bond_amount: FixedPoint,
-        maturity_time: FixedPoint,
-        current_time: FixedPoint
+        maturity_time: U256,
+        current_time:U256 
     ) -> FixedPoint {
         let normalized_time_remaining = self.calculate_time_remaining(maturity_time, current_time);
         // flat_fee = (d_y * (1 - t) * phi_flat) / c
@@ -61,12 +64,12 @@ impl State {
 
     fn calculate_time_remaining(
         &self,
-        maturity_time: FixedPoint,
-        current_time: FixedPoint
+        maturity_time: U256,
+        current_time: U256 
     ) -> FixedPoint {
-        let latest_checkpoint = self.get_latest_checkpoint(current_time); 
+        let latest_checkpoint = self.to_checkpoint(current_time); 
         let time_remaining = if maturity_time > latest_checkpoint {
-            maturity_time - latest_checkpoint
+            fixed!(maturity_time - latest_checkpoint)
         } else {
             fixed!(0)
         };
@@ -77,12 +80,4 @@ impl State {
         time_remaining
     }
 
-    /// Gets the most recent checkpoint time.
-    /// @return latestCheckpoint The latest checkpoint.
-    fn get_latest_checkpoint(
-        &self,
-        current_time: FixedPoint,
-    ) -> FixedPoint {
-        current_time - (current_time % self.checkpoint_duration())
-    }
 }

--- a/crates/hyperdrive-math/src/long/fees.rs
+++ b/crates/hyperdrive-math/src/long/fees.rs
@@ -1,8 +1,6 @@
-
 use ethers::types::U256;
 use fixed_point::FixedPoint;
 use fixed_point_macros::fixed;
-
 
 use crate::State;
 
@@ -37,7 +35,7 @@ impl State {
         &self,
         bond_amount: FixedPoint,
         maturity_time: U256,
-        current_time: U256 
+        current_time: U256,
     ) -> FixedPoint {
         let normalized_time_remaining = self.calculate_time_remaining(maturity_time, current_time);
         // curve_fee = ((1 - p) * phi_curve * d_y * t) / c
@@ -52,7 +50,7 @@ impl State {
         &self,
         bond_amount: FixedPoint,
         maturity_time: U256,
-        current_time:U256 
+        current_time: U256,
     ) -> FixedPoint {
         let normalized_time_remaining = self.calculate_time_remaining(maturity_time, current_time);
         // flat_fee = (d_y * (1 - t) * phi_flat) / c
@@ -61,23 +59,4 @@ impl State {
             self.vault_share_price(),
         ) * self.flat_fee()
     }
-
-    fn calculate_time_remaining(
-        &self,
-        maturity_time: U256,
-        current_time: U256 
-    ) -> FixedPoint {
-        let latest_checkpoint = self.to_checkpoint(current_time); 
-        let time_remaining = if maturity_time > latest_checkpoint {
-            FixedPoint::from(maturity_time - latest_checkpoint)
-        } else {
-            fixed!(0)
-        };
-
-        // NOTE: Round down to underestimate the time remaining.
-        let time_remaining = time_remaining.div_down(self.position_duration());
-
-        time_remaining
-    }
-
 }

--- a/crates/hyperdrive-math/src/long/fees.rs
+++ b/crates/hyperdrive-math/src/long/fees.rs
@@ -37,7 +37,8 @@ impl State {
         maturity_time: U256,
         current_time: U256,
     ) -> FixedPoint {
-        let normalized_time_remaining = self.calculate_normalized_time_remaining(maturity_time, current_time);
+        let normalized_time_remaining =
+            self.calculate_normalized_time_remaining(maturity_time, current_time);
         // curve_fee = ((1 - p) * phi_curve * d_y * t) / c
         self.curve_fee()
             * (fixed!(1e18) - self.get_spot_price())
@@ -52,7 +53,8 @@ impl State {
         maturity_time: U256,
         current_time: U256,
     ) -> FixedPoint {
-        let normalized_time_remaining = self.calculate_normalized_time_remaining(maturity_time, current_time);
+        let normalized_time_remaining =
+            self.calculate_normalized_time_remaining(maturity_time, current_time);
         // flat_fee = (d_y * (1 - t) * phi_flat) / c
         bond_amount.mul_div_down(
             fixed!(1e18) - normalized_time_remaining,

--- a/crates/hyperdrive-math/src/long/fees.rs
+++ b/crates/hyperdrive-math/src/long/fees.rs
@@ -69,7 +69,7 @@ impl State {
     ) -> FixedPoint {
         let latest_checkpoint = self.to_checkpoint(current_time); 
         let time_remaining = if maturity_time > latest_checkpoint {
-            fixed!(maturity_time - latest_checkpoint)
+            FixedPoint::from(maturity_time - latest_checkpoint)
         } else {
             fixed!(0)
         };

--- a/crates/hyperdrive-math/src/lp.rs
+++ b/crates/hyperdrive-math/src/lp.rs
@@ -26,13 +26,13 @@ impl State {
     /// Calculates the present value of LPs capital in the pool.
     pub fn calculate_present_value(&self, current_block_timestamp: U256) -> FixedPoint {
         // Calculate the average time remaining for the longs and shorts.
-        let long_average_time_remaining = self.time_remaining_scaled(
-            current_block_timestamp,
+        let long_average_time_remaining = self.calculate_normalized_time_remaining(
             self.long_average_maturity_time().into(),
-        );
-        let short_average_time_remaining = self.time_remaining_scaled(
             current_block_timestamp,
+        );
+        let short_average_time_remaining = self.calculate_normalized_time_remaining(
             self.short_average_maturity_time().into(),
+            current_block_timestamp,
         );
 
         let present_value: I256 = I256::try_from(self.share_reserves()).unwrap()
@@ -206,15 +206,15 @@ mod tests {
                     minimum_share_reserves: state.config.minimum_share_reserves,
                     minimum_transaction_amount: state.config.minimum_transaction_amount,
                     long_average_time_remaining: state
-                        .time_remaining_scaled(
-                            current_block_timestamp.into(),
+                        .calculate_normalized_time_remaining(
                             state.long_average_maturity_time().into(),
+                            current_block_timestamp.into(),
                         )
                         .into(),
                     short_average_time_remaining: state
-                        .time_remaining_scaled(
-                            current_block_timestamp.into(),
+                        .calculate_normalized_time_remaining(
                             state.short_average_maturity_time().into(),
+                            current_block_timestamp.into(),
                         )
                         .into(),
                     shorts_outstanding: state.shorts_outstanding().into(),
@@ -242,13 +242,13 @@ mod tests {
         for _ in 0..*FAST_FUZZ_RUNS {
             let state = rng.gen::<State>();
             let current_block_timestamp = rng.gen_range(fixed!(1)..=fixed!(1e4));
-            let long_average_time_remaining = state.time_remaining_scaled(
-                current_block_timestamp.into(),
+            let long_average_time_remaining = state.calculate_normalized_time_remaining(
                 state.long_average_maturity_time().into(),
-            );
-            let short_average_time_remaining = state.time_remaining_scaled(
                 current_block_timestamp.into(),
+            );
+            let short_average_time_remaining = state.calculate_normalized_time_remaining(
                 state.short_average_maturity_time().into(),
+                current_block_timestamp.into(),
             );
             let actual = panic::catch_unwind(|| {
                 state.calculate_net_curve_trade(
@@ -294,13 +294,13 @@ mod tests {
         for _ in 0..*FAST_FUZZ_RUNS {
             let state = rng.gen::<State>();
             let current_block_timestamp = rng.gen_range(fixed!(1)..=fixed!(1e4));
-            let long_average_time_remaining = state.time_remaining_scaled(
-                current_block_timestamp.into(),
+            let long_average_time_remaining = state.calculate_normalized_time_remaining(
                 state.long_average_maturity_time().into(),
-            );
-            let short_average_time_remaining = state.time_remaining_scaled(
                 current_block_timestamp.into(),
+            );
+            let short_average_time_remaining = state.calculate_normalized_time_remaining(
                 state.short_average_maturity_time().into(),
+                current_block_timestamp.into(),
             );
             let actual = panic::catch_unwind(|| {
                 state.calculate_net_flat_trade(

--- a/crates/hyperdrive-math/src/short/close.rs
+++ b/crates/hyperdrive-math/src/short/close.rs
@@ -12,7 +12,8 @@ impl State {
         current_time: U256,
     ) -> FixedPoint {
         let bond_amount = bond_amount.into();
-        let normalized_time_remaining = self.calculate_normalized_time_remaining(maturity_time, current_time);
+        let normalized_time_remaining =
+            self.calculate_normalized_time_remaining(maturity_time, current_time);
 
         // NOTE: We overestimate the trader's share payment to avoid sandwiches.
         //
@@ -158,7 +159,7 @@ mod tests {
         for _ in 0..*FAST_FUZZ_RUNS {
             let state = rng.gen::<State>();
             let in_ = rng.gen_range(fixed!(0)..=state.bond_reserves());
-            let maturity_time = state.checkpoint_duration();
+            let maturity_time = state.position_duration();
             let current_time = rng.gen_range(fixed!(0)..=maturity_time);
             let actual = panic::catch_unwind(|| {
                 state.calculate_close_short_flat_plus_curve(
@@ -168,8 +169,8 @@ mod tests {
                 )
             });
 
-            let normalized_time_remaining =
-                state.calculate_normalized_time_remaining(maturity_time.into(), current_time.into());
+            let normalized_time_remaining = state
+                .calculate_normalized_time_remaining(maturity_time.into(), current_time.into());
             match mock
                 .calculate_close_short(
                     state.effective_share_reserves().into(),

--- a/crates/hyperdrive-math/src/short/close.rs
+++ b/crates/hyperdrive-math/src/short/close.rs
@@ -12,7 +12,7 @@ impl State {
         current_time: U256,
     ) -> FixedPoint {
         let bond_amount = bond_amount.into();
-        let normalized_time_remaining = self.calculate_time_remaining(maturity_time, current_time);
+        let normalized_time_remaining = self.calculate_normalized_time_remaining(maturity_time, current_time);
 
         // NOTE: We overestimate the trader's share payment to avoid sandwiches.
         //
@@ -169,7 +169,7 @@ mod tests {
             });
 
             let normalized_time_remaining =
-                state.calculate_time_remaining(maturity_time.into(), current_time.into());
+                state.calculate_normalized_time_remaining(maturity_time.into(), current_time.into());
             match mock
                 .calculate_close_short(
                     state.effective_share_reserves().into(),

--- a/crates/hyperdrive-math/src/short/close.rs
+++ b/crates/hyperdrive-math/src/short/close.rs
@@ -1,3 +1,4 @@
+use ethers::types::U256;
 use fixed_point::FixedPoint;
 use fixed_point_macros::fixed;
 
@@ -7,10 +8,11 @@ impl State {
     fn calculate_close_short_flat_plus_curve<F: Into<FixedPoint>>(
         &self,
         bond_amount: F,
-        normalized_time_remaining: F,
+        maturity_time: U256,
+        current_time: U256,
     ) -> FixedPoint {
         let bond_amount = bond_amount.into();
-        let normalized_time_remaining = normalized_time_remaining.into();
+        let normalized_time_remaining = self.calculate_time_remaining(maturity_time, current_time);
 
         // NOTE: We overestimate the trader's share payment to avoid sandwiches.
         //
@@ -68,18 +70,18 @@ impl State {
         bond_amount: F,
         open_vault_share_price: F,
         close_vault_share_price: F,
-        normalized_time_remaining: F,
+        maturity_time: U256,
+        current_time: U256,
     ) -> FixedPoint {
         let bond_amount = bond_amount.into();
         let open_vault_share_price = open_vault_share_price.into();
         let close_vault_share_price = close_vault_share_price.into();
-        let normalized_time_remaining = normalized_time_remaining.into();
 
         // Calculate flat + curve and subtract the fees from the trade.
-        let share_reserves_delta = self
-            .calculate_close_short_flat_plus_curve(bond_amount, normalized_time_remaining)
-            + self.close_short_curve_fee(bond_amount, normalized_time_remaining)
-            + self.close_short_flat_fee(bond_amount, normalized_time_remaining);
+        let share_reserves_delta =
+            self.calculate_close_short_flat_plus_curve(bond_amount, maturity_time, current_time)
+                + self.close_short_curve_fee(bond_amount, maturity_time, current_time)
+                + self.close_short_flat_fee(bond_amount, maturity_time, current_time);
 
         // Calculate the share proceeds owed to the short.
         self.calculate_short_proceeds(
@@ -156,10 +158,18 @@ mod tests {
         for _ in 0..*FAST_FUZZ_RUNS {
             let state = rng.gen::<State>();
             let in_ = rng.gen_range(fixed!(0)..=state.bond_reserves());
-            let normalized_time_remaining = rng.gen_range(fixed!(0)..=fixed!(1e18));
+            let maturity_time = state.checkpoint_duration();
+            let current_time = rng.gen_range(fixed!(0)..=maturity_time);
             let actual = panic::catch_unwind(|| {
-                state.calculate_close_short_flat_plus_curve(in_, normalized_time_remaining)
+                state.calculate_close_short_flat_plus_curve(
+                    in_,
+                    maturity_time.into(),
+                    current_time.into(),
+                )
             });
+
+            let normalized_time_remaining =
+                state.calculate_time_remaining(maturity_time.into(), current_time.into());
             match mock
                 .calculate_close_short(
                     state.effective_share_reserves().into(),

--- a/crates/hyperdrive-math/src/short/fees.rs
+++ b/crates/hyperdrive-math/src/short/fees.rs
@@ -31,7 +31,8 @@ impl State {
         maturity_time: U256,
         current_time: U256,
     ) -> FixedPoint {
-        let normalized_time_remaining = self.calculate_normalized_time_remaining(maturity_time, current_time);
+        let normalized_time_remaining =
+            self.calculate_normalized_time_remaining(maturity_time, current_time);
 
         // ((1 - p) * phi_curve * d_y * t) / c
         self.curve_fee()
@@ -47,7 +48,8 @@ impl State {
         maturity_time: U256,
         current_time: U256,
     ) -> FixedPoint {
-        let normalized_time_remaining = self.calculate_normalized_time_remaining(maturity_time, current_time);
+        let normalized_time_remaining =
+            self.calculate_normalized_time_remaining(maturity_time, current_time);
         // flat fee = (d_y * (1 - t) * phi_flat) / c
         bond_amount.mul_div_down(
             fixed!(1e18) - normalized_time_remaining,

--- a/crates/hyperdrive-math/src/short/fees.rs
+++ b/crates/hyperdrive-math/src/short/fees.rs
@@ -31,7 +31,7 @@ impl State {
         maturity_time: U256,
         current_time: U256,
     ) -> FixedPoint {
-        let normalized_time_remaining = self.calculate_time_remaining(maturity_time, current_time);
+        let normalized_time_remaining = self.calculate_normalized_time_remaining(maturity_time, current_time);
 
         // ((1 - p) * phi_curve * d_y * t) / c
         self.curve_fee()
@@ -47,7 +47,7 @@ impl State {
         maturity_time: U256,
         current_time: U256,
     ) -> FixedPoint {
-        let normalized_time_remaining = self.calculate_time_remaining(maturity_time, current_time);
+        let normalized_time_remaining = self.calculate_normalized_time_remaining(maturity_time, current_time);
         // flat fee = (d_y * (1 - t) * phi_flat) / c
         bond_amount.mul_div_down(
             fixed!(1e18) - normalized_time_remaining,

--- a/crates/hyperdrive-math/src/short/fees.rs
+++ b/crates/hyperdrive-math/src/short/fees.rs
@@ -1,3 +1,4 @@
+use ethers::types::U256;
 use fixed_point::FixedPoint;
 use fixed_point_macros::fixed;
 
@@ -27,8 +28,11 @@ impl State {
     pub fn close_short_curve_fee(
         &self,
         bond_amount: FixedPoint,
-        normalized_time_remaining: FixedPoint,
+        maturity_time: U256,
+        current_time: U256,
     ) -> FixedPoint {
+        let normalized_time_remaining = self.calculate_time_remaining(maturity_time, current_time);
+
         // ((1 - p) * phi_curve * d_y * t) / c
         self.curve_fee()
             * (fixed!(1e18) - self.get_spot_price())
@@ -40,8 +44,10 @@ impl State {
     pub fn close_short_flat_fee(
         &self,
         bond_amount: FixedPoint,
-        normalized_time_remaining: FixedPoint,
+        maturity_time: U256,
+        current_time: U256,
     ) -> FixedPoint {
+        let normalized_time_remaining = self.calculate_time_remaining(maturity_time, current_time);
         // flat fee = (d_y * (1 - t) * phi_flat) / c
         bond_amount.mul_div_down(
             fixed!(1e18) - normalized_time_remaining,


### PR DESCRIPTION
This PR unifies the calculation of `normalized_time_remaining` into a `calculate_normalized_time_remaining` method based on current time and maturity time. 

This allows other sdk methods like `close_long()` and `close_short()` to take in current time and maturity time as arguments and return accurate price quotes.