### PR TITLE
Fixed an intermittent failure in the sandwich test

### DIFF
--- a/contracts/src/internal/HyperdriveLong.sol
+++ b/contracts/src/internal/HyperdriveLong.sol
@@ -158,11 +158,16 @@ abstract contract HyperdriveLong is IHyperdriveEvents, HyperdriveLP {
             revert IHyperdrive.MinimumTransactionAmount();
         }
 
-        // Perform a checkpoint at the maturity time. This ensures the long and
-        // all of the other positions in the checkpoint are closed. This will
-        // have no effect if the maturity time is in the future.
+        // If the long hasn't matured, we checkpoint the latest checkpoint.
+        // Otherwise, we perform a checkpoint at the time the long matured.
+        // This ensures the long and all of the other positions in the
+        // checkpoint are closed.
         uint256 vaultSharePrice = _pricePerVaultShare();
-        _applyCheckpoint(_maturityTime, vaultSharePrice);
+        if (block.timestamp < _maturityTime) {
+            _applyCheckpoint(_latestCheckpoint(), vaultSharePrice);
+        } else {
+            _applyCheckpoint(_maturityTime, vaultSharePrice);
+        }
 
         // Burn the longs that are being closed.
         _burn(

--- a/contracts/src/internal/HyperdriveShort.sol
+++ b/contracts/src/internal/HyperdriveShort.sol
@@ -170,9 +170,16 @@ abstract contract HyperdriveShort is IHyperdriveEvents, HyperdriveLP {
             revert IHyperdrive.MinimumTransactionAmount();
         }
 
-        // Perform a checkpoint.
+        // If the short hasn't matured, we checkpoint the latest checkpoint.
+        // Otherwise, we perform a checkpoint at the time the short matured.
+        // This ensures the short and all of the other positions in the
+        // checkpoint are closed.
         uint256 vaultSharePrice = _pricePerVaultShare();
-        _applyCheckpoint(_maturityTime, vaultSharePrice);
+        if (block.timestamp < _maturityTime) {
+            _applyCheckpoint(_latestCheckpoint(), vaultSharePrice);
+        } else {
+            _applyCheckpoint(_maturityTime, vaultSharePrice);
+        }
 
         // Burn the shorts that are being closed.
         _burn(

--- a/test/integrations/hyperdrive/SandwichTest.t.sol
+++ b/test/integrations/hyperdrive/SandwichTest.t.sol
@@ -11,11 +11,9 @@ contract SandwichTest is HyperdriveTest {
     using HyperdriveUtils for *;
     using Lib for *;
 
-    function test_sandwich_trades(uint8 _apr, uint64 _timeDelta) external {
-        uint256 apr = uint256(_apr) * 0.01e18;
-        uint256 timeDelta = uint256(_timeDelta);
-        vm.assume(apr >= 0.01e18 && apr <= 0.2e18);
-        vm.assume(timeDelta <= ONE && timeDelta >= 0);
+    function test_sandwich_trades(uint256 apr, uint256 timeDelta) external {
+        apr = apr.normalizeToRange(0.01e18, 0.2e18);
+        timeDelta = timeDelta.normalizeToRange(0, ONE);
 
         // Deploy the pool and initialize the market
         {
@@ -230,10 +228,8 @@ contract SandwichTest is HyperdriveTest {
         assertGe(withdrawalProceeds, contribution);
     }
 
-    // TODO: Use the normalize function to improve this test.
-    function test_sandwich_lp(uint8 _apr) external {
-        uint256 apr = uint256(_apr) * 0.01e18;
-        vm.assume(apr >= 0.01e18 && apr <= 0.2e18);
+    function test_sandwich_lp(uint256 apr) external {
+        apr = apr.normalizeToRange(0.01e18, 0.2e18);
 
         // Deploy the pool with fees.
         {


### PR DESCRIPTION
Fixes: #769.

There are more details in the issue, but the TL;DR is that this is an exceptional edge case with zero fees. Both cases were addressed by adding a curve fee of `0.0001e18`.