### PR TITLE
Add `calculate_idle_share_reserves` to rust sdk

### DIFF
--- a/crates/hyperdrive-math/src/lp.rs
+++ b/crates/hyperdrive-math/src/lp.rs
@@ -12,7 +12,7 @@ impl State {
         // NOTE: Round up to underestimate the pool's idle.
         let long_exposure = self.long_exposure().div_up(self.vault_share_price());
 
-        let mut idle_shares_in_base = fixed!(0e18);
+        let mut idle_shares_in_base = fixed!(0);
         if (self.share_reserves() > long_exposure + self.minimum_share_reserves()) {
             idle_shares_in_base =
                 (self.share_reserves() - long_exposure - self.minimum_share_reserves())

--- a/crates/hyperdrive-math/src/lp.rs
+++ b/crates/hyperdrive-math/src/lp.rs
@@ -7,6 +7,21 @@ use fixed_point_macros::{fixed, int256};
 use crate::{State, YieldSpace};
 
 impl State {
+    /// Calculates the number of base that are not reserved by open positions.
+    pub fn calculate_idle_share_reserves_in_base(&self) -> FixedPoint {
+        // NOTE: Round up to underestimate the pool's idle.
+        let long_exposure = self.long_exposure().div_up(self.vault_share_price());
+
+        let mut idle_shares_in_base = fixed!(0e18);
+        if (self.share_reserves() > long_exposure + self.minimum_share_reserves()) {
+            idle_shares_in_base =
+                (self.share_reserves() - long_exposure - self.minimum_share_reserves())
+                    * self.vault_share_price();
+        }
+
+        idle_shares_in_base
+    }
+
     /// Calculates the present value of LPs capital in the pool.
     pub fn calculate_present_value(&self, current_block_timestamp: U256) -> FixedPoint {
         // Calculate the average time remaining for the longs and shorts.

--- a/crates/hyperdrive-math/src/lp.rs
+++ b/crates/hyperdrive-math/src/lp.rs
@@ -12,6 +12,7 @@ impl State {
         // NOTE: Round up to underestimate the pool's idle.
         let long_exposure = self.long_exposure().div_up(self.vault_share_price());
 
+        // Calculate the idle base reserves.
         let mut idle_shares_in_base = fixed!(0);
         if (self.share_reserves() > long_exposure + self.minimum_share_reserves()) {
             idle_shares_in_base =

--- a/crates/hyperdrive-math/src/utils.rs
+++ b/crates/hyperdrive-math/src/utils.rs
@@ -98,32 +98,6 @@ pub fn calculate_initial_bond_reserves(
         .mul_down(inner)
 }
 
-/// @dev Calculates the number of base that are not reserved by
-///      open positions.
-/// @param vault_share_price The current vault share price.
-/// @param share_reserves The current share reserves, from market state
-/// @param long_exposure The current long exposure, from market state
-/// @param minimum_share_reserves The minimum share reserves, from pool config
-/// @return idleShares The amount of shares that are available for LPs to
-///         withdraw.
-pub fn calculate_idle_share_reserves_in_base(
-    vault_share_price: FixedPoint,
-    share_reserves: FixedPoint,
-    long_exposure: FixedPoint,
-    minimum_share_reserves: FixedPoint,
-) -> FixedPoint {
-    // NOTE: Round up to underestimate the pool's idle.
-    let long_exposure = long_exposure.div_up(vault_share_price);
-
-    let mut idle_shares_in_base = fixed!(0e18);
-    if (share_reserves > long_exposure + minimum_share_reserves) {
-        idle_shares_in_base =
-            (share_reserves - long_exposure - minimum_share_reserves) * vault_share_price;
-    }
-
-    idle_shares_in_base
-}
-
 #[cfg(test)]
 mod tests {
     use std::panic;

--- a/crates/hyperdrive-math/src/utils.rs
+++ b/crates/hyperdrive-math/src/utils.rs
@@ -98,15 +98,15 @@ pub fn calculate_initial_bond_reserves(
         .mul_down(inner)
 }
 
-/// @dev Calculates the number of share reserves that are not reserved by
+/// @dev Calculates the number of base that are not reserved by
 ///      open positions.
 /// @param vault_share_price The current vault share price.
 /// @param share_reserves The current share reserves, from market state
 /// @param long_exposure The current long exposure, from market state
-/// @param minimum_share_reserves The minimum share reserves, from pool config 
+/// @param minimum_share_reserves The minimum share reserves, from pool config
 /// @return idleShares The amount of shares that are available for LPs to
 ///         withdraw.
-pub fn calculate_idle_share_reserves(
+pub fn calculate_idle_share_reserves_in_base(
     vault_share_price: FixedPoint,
     share_reserves: FixedPoint,
     long_exposure: FixedPoint,
@@ -115,12 +115,12 @@ pub fn calculate_idle_share_reserves(
     // NOTE: Round up to underestimate the pool's idle.
     let long_exposure = long_exposure.div_up(vault_share_price);
 
-    let mut idle_shares = fixed!(0e18);
+    let mut idle_shares_in_base = fixed!(0e18);
     if (share_reserves > long_exposure + minimum_share_reserves) {
-        idle_shares = share_reserves - long_exposure - minimum_share_reserves;
+        idle_shares_in_base = (share_reserves - long_exposure - minimum_share_reserves) * vault_share_price;
     }
 
-    idle_shares
+    idle_shares_in_base
 }
 
 #[cfg(test)]

--- a/crates/hyperdrive-math/src/utils.rs
+++ b/crates/hyperdrive-math/src/utils.rs
@@ -117,7 +117,8 @@ pub fn calculate_idle_share_reserves_in_base(
 
     let mut idle_shares_in_base = fixed!(0e18);
     if (share_reserves > long_exposure + minimum_share_reserves) {
-        idle_shares_in_base = (share_reserves - long_exposure - minimum_share_reserves) * vault_share_price;
+        idle_shares_in_base =
+            (share_reserves - long_exposure - minimum_share_reserves) * vault_share_price;
     }
 
     idle_shares_in_base

--- a/crates/hyperdrive-math/src/utils.rs
+++ b/crates/hyperdrive-math/src/utils.rs
@@ -98,6 +98,31 @@ pub fn calculate_initial_bond_reserves(
         .mul_down(inner)
 }
 
+/// @dev Calculates the number of share reserves that are not reserved by
+///      open positions.
+/// @param vault_share_price The current vault share price.
+/// @param share_reserves The current share reserves, from market state
+/// @param long_exposure The current long exposure, from market state
+/// @param minimum_share_reserves The minimum share reserves, from pool config 
+/// @return idleShares The amount of shares that are available for LPs to
+///         withdraw.
+pub fn calculate_idle_share_reserves(
+    vault_share_price: FixedPoint,
+    share_reserves: FixedPoint,
+    long_exposure: FixedPoint,
+    minimum_share_reserves: FixedPoint,
+) -> FixedPoint {
+    // NOTE: Round up to underestimate the pool's idle.
+    let long_exposure = long_exposure.div_up(vault_share_price);
+
+    let mut idle_shares = fixed!(0e18);
+    if (share_reserves > long_exposure + minimum_share_reserves) {
+        idle_shares = share_reserves - long_exposure - minimum_share_reserves;
+    }
+
+    idle_shares
+}
+
 #[cfg(test)]
 mod tests {
     use std::panic;


### PR DESCRIPTION
This calculation fixes the broken calculation for `Available Liquidity` on the frontend.