### PR TITLE
Add `renzo()` and `ezETH()` getters

### DIFF
--- a/contracts/src/instances/ezeth/EzETHTarget0.sol
+++ b/contracts/src/instances/ezeth/EzETHTarget0.sol
@@ -36,6 +36,12 @@ contract EzETHTarget0 is HyperdriveTarget0, EzETHBase {
         _revert(abi.encode(_restakeManager));
     }
 
+    /// @notice Gets the ezETH token contract.
+    /// @return The ezETH token contract.
+    function ezETH() external view returns (IERC20) {
+        _revert(abi.encode(_restakeManager.ezETH()));
+    }
+
     /// @notice Returns the MultiToken's decimals.
     /// @return The MultiToken's decimals.
     function decimals() external pure override returns (uint8) {

--- a/contracts/src/instances/ezeth/EzETHTarget0.sol
+++ b/contracts/src/instances/ezeth/EzETHTarget0.sol
@@ -30,6 +30,12 @@ contract EzETHTarget0 is HyperdriveTarget0, EzETHBase {
 
     /// Extras ///
 
+    /// @notice Returns the Renzo contract.
+    /// @return _restakeManager The Renzo contract.
+    function renzo() external view returns (IRestakeManager) {
+        _revert(abi.encode(_restakeManager));
+    }
+
     /// @notice Returns the MultiToken's decimals.
     /// @return The MultiToken's decimals.
     function decimals() external pure override returns (uint8) {

--- a/contracts/src/interfaces/IEzETHHyperdriveRead.sol
+++ b/contracts/src/interfaces/IEzETHHyperdriveRead.sol
@@ -8,4 +8,8 @@ interface IEzETHHyperdriveRead is IHyperdriveRead {
     /// @notice Gets the Renzo contract used as this pool's yield source.
     /// @return The renzo contract.
     function renzo() external view returns (IRestakeManager);
+
+    /// @notice Gets the ezETH token contract.
+    /// @return The ezETH token contract.
+    function ezETH() external view returns (IERC20);
 }

--- a/contracts/src/interfaces/IEzETHHyperdriveRead.sol
+++ b/contracts/src/interfaces/IEzETHHyperdriveRead.sol
@@ -3,6 +3,7 @@ pragma solidity 0.8.20;
 
 import { IHyperdriveRead } from "./IHyperdriveRead.sol";
 import { IRestakeManager } from "./IRenzo.sol";
+import { IERC20 } from "contracts/src/interfaces/IERC20.sol";
 
 interface IEzETHHyperdriveRead is IHyperdriveRead {
     /// @notice Gets the Renzo contract used as this pool's yield source.

--- a/test/instances/ezETH/EzETHHyperdrive.t.sol
+++ b/test/instances/ezETH/EzETHHyperdrive.t.sol
@@ -12,6 +12,7 @@ import { EzETHTarget4Deployer } from "contracts/src/deployers/ezeth/EzETHTarget4
 import { HyperdriveFactory } from "contracts/src/factory/HyperdriveFactory.sol";
 import { IERC20 } from "contracts/src/interfaces/IERC20.sol";
 import { IHyperdrive } from "contracts/src/interfaces/IHyperdrive.sol";
+import { IEzETHHyperdriveRead } from "contracts/src/interfaces/IEzETHHyperdriveRead.sol";
 import { IRestakeManager } from "contracts/src/interfaces/IRenzo.sol";
 import { IRenzoOracle, IDepositQueue } from "contracts/src/interfaces/IRenzo.sol";
 import { AssetId } from "contracts/src/libraries/AssetId.sol";
@@ -234,6 +235,19 @@ contract EzETHHyperdriveTest is HyperdriveTest {
 
         // Start recording event logs.
         vm.recordLogs();
+    }
+
+    /// Getters ///
+
+    function test_getters() external {
+        assertEq(
+            address(IEzETHHyperdriveRead(address(hyperdrive)).renzo()),
+            address(RESTAKE_MANAGER)
+        );
+        assertEq(
+            address(IEzETHHyperdriveRead(address(hyperdrive)).ezETH()),
+            address(EZETH)
+        );
     }
 
     /// Deploy and Initialize ///


### PR DESCRIPTION
Add `renzo()` and `ezETH` getters so that the main entrypoint contract is publicly accessible from the ezETH implementation of hyperdrive.  Note that for this implementation, the vault differs from that of lido in that the token `ezETH` is separate from the vault, `renzo`