### PR TITLE
add get_targeted_long

### DIFF
--- a/crates/hyperdrive-math/src/long.rs
+++ b/crates/hyperdrive-math/src/long.rs
@@ -2,3 +2,4 @@ mod close;
 mod fees;
 mod max;
 mod open;
+mod targeted;

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -340,7 +340,7 @@ impl State {
     /// It's possible that the pool is insolvent after opening a long. In this
     /// case, we return `None` since the fixed point library can't represent
     /// negative numbers.
-    pub fn solvency_after_long(
+    pub(super) fn solvency_after_long(
         &self,
         base_amount: FixedPoint,
         bond_amount: FixedPoint,
@@ -380,7 +380,10 @@ impl State {
     /// This derivative is negative since solvency decreases as more longs are
     /// opened. We use the negation of the derivative to stay in the positive
     /// domain, which allows us to use the fixed point library.
-    pub fn solvency_after_long_derivative(&self, base_amount: FixedPoint) -> Option<FixedPoint> {
+    pub(super) fn solvency_after_long_derivative(
+        &self,
+        base_amount: FixedPoint,
+    ) -> Option<FixedPoint> {
         let maybe_derivative = self.long_amount_derivative(base_amount);
         maybe_derivative.map(|derivative| {
             (derivative
@@ -419,7 +422,7 @@ impl State {
     /// $$
     /// c'(x) = \phi_{c} \cdot \left( \tfrac{1}{p} - 1 \right)
     /// $$
-    pub fn long_amount_derivative(&self, base_amount: FixedPoint) -> Option<FixedPoint> {
+    pub(super) fn long_amount_derivative(&self, base_amount: FixedPoint) -> Option<FixedPoint> {
         let share_amount = base_amount / self.vault_share_price();
         let inner =
             self.initial_vault_share_price() * (self.effective_share_reserves() + share_amount);

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -340,7 +340,7 @@ impl State {
     /// It's possible that the pool is insolvent after opening a long. In this
     /// case, we return `None` since the fixed point library can't represent
     /// negative numbers.
-    fn solvency_after_long(
+    pub fn solvency_after_long(
         &self,
         base_amount: FixedPoint,
         bond_amount: FixedPoint,
@@ -380,7 +380,7 @@ impl State {
     /// This derivative is negative since solvency decreases as more longs are
     /// opened. We use the negation of the derivative to stay in the positive
     /// domain, which allows us to use the fixed point library.
-    fn solvency_after_long_derivative(&self, base_amount: FixedPoint) -> Option<FixedPoint> {
+    pub fn solvency_after_long_derivative(&self, base_amount: FixedPoint) -> Option<FixedPoint> {
         let maybe_derivative = self.long_amount_derivative(base_amount);
         maybe_derivative.map(|derivative| {
             (derivative
@@ -419,7 +419,7 @@ impl State {
     /// $$
     /// c'(x) = \phi_{c} \cdot \left( \tfrac{1}{p} - 1 \right)
     /// $$
-    fn long_amount_derivative(&self, base_amount: FixedPoint) -> Option<FixedPoint> {
+    pub fn long_amount_derivative(&self, base_amount: FixedPoint) -> Option<FixedPoint> {
         let share_amount = base_amount / self.vault_share_price();
         let inner =
             self.initial_vault_share_price() * (self.effective_share_reserves() + share_amount);

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -624,7 +624,7 @@ mod tests {
             let spot_price_after_long = bob
                 .get_state()
                 .await?
-                .calculate_spot_price_after_long(max_long, None);
+                .calculate_spot_price_after_long(max_long, None)?;
             bob.open_long(max_long, None, None).await?;
 
             // One of three things should be true after opening the long:

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -83,7 +83,7 @@ impl State {
             self.max_long_guess(absolute_max_base_amount, checkpoint_exposure);
         let mut maybe_solvency = self.solvency_after_long(
             max_base_amount,
-            self.calculate_open_long(max_base_amount),
+            self.calculate_open_long(max_base_amount).unwrap(),
             checkpoint_exposure,
         );
         if maybe_solvency.is_none() {
@@ -121,7 +121,7 @@ impl State {
             let possible_max_base_amount = max_base_amount + solvency / maybe_derivative.unwrap();
             maybe_solvency = self.solvency_after_long(
                 possible_max_base_amount,
-                self.calculate_open_long(possible_max_base_amount),
+                self.calculate_open_long(possible_max_base_amount).unwrap(),
                 checkpoint_exposure,
             );
             if let Some(s) = maybe_solvency {

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -36,7 +36,7 @@ impl State {
 
         // Throw an error if opening the long would result in negative interest.
         let ending_spot_price =
-            self.calculate_spot_price_after_long(base_amount, long_amount.into());
+            self.calculate_spot_price_after_long(base_amount, long_amount.into())?;
         let max_spot_price = self.calculate_max_spot_price();
         if ending_spot_price > max_spot_price {
             return Err(eyre!(
@@ -82,7 +82,6 @@ impl State {
 
 #[cfg(test)]
 mod tests {
-    use eyre::Result;
     use fixed_point_macros::fixed;
     use rand::{thread_rng, Rng};
     use test_utils::{
@@ -126,7 +125,7 @@ mod tests {
             let expected_spot_price = bob
                 .get_state()
                 .await?
-                .calculate_spot_price_after_long(base_paid, None);
+                .calculate_spot_price_after_long(base_paid, None)?;
 
             // Open the long.
             bob.open_long(base_paid, None, None).await?;
@@ -190,7 +189,7 @@ mod tests {
             let expected_spot_rate = bob
                 .get_state()
                 .await?
-                .calculate_spot_rate_after_long(base_paid, None);
+                .calculate_spot_rate_after_long(base_paid, None)?;
 
             // Open the long.
             bob.open_long(base_paid, None, None).await?;

--- a/crates/hyperdrive-math/src/long/targeted.rs
+++ b/crates/hyperdrive-math/src/long/targeted.rs
@@ -1,0 +1,233 @@
+use ethers::{providers::maybe, types::I256};
+use fixed_point::FixedPoint;
+use fixed_point_macros::fixed;
+
+use crate::{State, YieldSpace};
+
+impl State {
+    /// Gets a target long that can be opened given a budget to achieve a desired fixed rate.
+    pub fn get_targeted_long<F: Into<FixedPoint>, I: Into<I256>>(
+        &self,
+        budget: F,
+        target_rate: F,
+        checkpoint_exposure: I,
+        maybe_max_iterations: Option<usize>,
+    ) -> FixedPoint {
+        let budget = budget.into();
+        let target_rate = target_rate.into();
+        let checkpoint_exposure = checkpoint_exposure.into();
+
+        // Estimate the long that achieves a target rate
+        let (absolute_target_base_amount, absolute_target_bond_amount) =
+            self.absolute_targeted_long(target_rate);
+        // Get the maximum long that brings the spot price to 1.
+        let max_base_amount = self.get_max_long(budget, checkpoint_exposure, maybe_max_iterations);
+        // Ensure that the target is less than the max.
+        let target_base_amount = absolute_target_base_amount.min(max_base_amount);
+        // Verify solvency.
+        if self
+            .solvency_after_long(
+                absolute_target_base_amount,
+                absolute_target_bond_amount,
+                checkpoint_exposure,
+            )
+            .is_some()
+        {
+            return target_base_amount.min(budget);
+        } else {
+            // TODO: Refine using an iterative method
+            panic!("Initial guess in `get_targeted_long` is insolvent.");
+        }
+    }
+
+    /// Calculates the long that should be opened to hit a target interest rate.
+    /// This calculation does not take Hyperdrive's solvency constraints into account and shouldn't be used directly.
+    fn absolute_targeted_long<F: Into<FixedPoint>>(
+        &self,
+        target_rate: F,
+    ) -> (FixedPoint, FixedPoint) {
+        //
+        // TODO: Docstring
+        //
+        let target_rate = target_rate.into();
+        let c_over_mu = self
+            .vault_share_price()
+            .div_up(self.initial_vault_share_price());
+        let scaled_rate = (target_rate.mul_up(self.position_duration()) + fixed!(1e18))
+            .pow(fixed!(1e18) / self.time_stretch());
+        let inner = (self.k_down()
+            / (c_over_mu + scaled_rate.pow(fixed!(1e18) - self.time_stretch())))
+        .pow(fixed!(1e18) / (fixed!(1e18) - self.time_stretch()));
+        let target_share_reserves = inner / self.initial_vault_share_price();
+
+        // Now that we have the target share reserves, we can calculate the
+        // target bond reserves using the formula:
+        //
+        // TODO: docstring
+        //
+        let target_bond_reserves = inner * scaled_rate;
+
+        // The absolute max base amount is given by:
+        //
+        // absolute_target_base_amount = c * (z_t - z)
+        let absolute_target_base_amount =
+            (target_share_reserves - self.effective_share_reserves()) * self.vault_share_price();
+
+        // The absolute max bond amount is given by:
+        //
+        // absolute_target_bond_amount = (y - y_t) - c(x)
+        let absolute_target_bond_amount = (self.bond_reserves() - target_bond_reserves)
+            - self.open_long_curve_fees(absolute_target_base_amount);
+
+        (absolute_target_base_amount, absolute_target_bond_amount)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use eyre::Result;
+    use rand::{thread_rng, Rng};
+    use test_utils::{
+        agent::Agent,
+        chain::{Chain, TestChain},
+        constants::FUZZ_RUNS,
+    };
+    use tracing_test::traced_test;
+
+    use super::*;
+
+    #[traced_test]
+    #[tokio::test]
+    async fn test_get_targeted_long() -> Result<()> {
+        // Spawn a test chain and create three agents -- Alice, Bob, and Claire. Alice
+        // is funded with a large amount of capital so that she can initialize
+        // the pool. Bob is funded with a small amount of capital so that we
+        // can test `get_targeted_long` when budget is the primary constraint.
+        // Claire is funded with a large amount of capital so tha we can test
+        // `get_targeted_long` when budget is not a constraint.
+        let mut rng = thread_rng();
+        let chain = TestChain::new(3).await?;
+        let (alice, bob, claire) = (
+            chain.accounts()[0].clone(),
+            chain.accounts()[1].clone(),
+            chain.accounts()[2].clone(),
+        );
+        let mut alice =
+            Agent::new(chain.client(alice).await?, chain.addresses().clone(), None).await?;
+        let mut bob = Agent::new(chain.client(bob).await?, chain.addresses(), None).await?;
+        let mut claire = Agent::new(chain.client(claire).await?, chain.addresses(), None).await?;
+        let config = bob.get_config().clone();
+
+        for _ in 0..*FUZZ_RUNS {
+            // Snapshot the chain.
+            let id = chain.snapshot().await?;
+
+            // Fund Alice and Bob.
+            let fixed_rate = rng.gen_range(fixed!(0.01e18)..=fixed!(0.1e18));
+            let contribution = rng.gen_range(fixed!(10_000e18)..=fixed!(500_000_000e18));
+            let budget = rng.gen_range(fixed!(10e18)..=fixed!(500_000_000e18));
+            alice.fund(contribution).await?; // large budget for initializing the pool
+            bob.fund(budget).await?; // small budget for resource-constrained targeted longs
+            claire.fund(contribution).await?; // large budget for unconstrained targeted longs
+
+            // Alice initializes the pool.
+            alice.initialize(fixed_rate, contribution, None).await?;
+
+            // Some of the checkpoint passes and variable interest accrues.
+            alice
+                .checkpoint(alice.latest_checkpoint().await?, None)
+                .await?;
+            let rate = rng.gen_range(fixed!(0)..=fixed!(0.5e18));
+            alice
+                .advance_time(
+                    rate,
+                    FixedPoint::from(config.checkpoint_duration) * fixed!(0.5e18),
+                )
+                .await?;
+
+            // Bob opens a targeted long.
+            let max_spot_price = bob.get_state().await?.get_max_spot_price();
+            let target_rate = fixed_rate - fixed!(1e18); // Bob can't afford this rate
+            let targeted_long = bob.get_targeted_long(target_rate, None).await?;
+            let spot_price_after_long = bob
+                .get_state()
+                .await?
+                .get_spot_price_after_long(targeted_long);
+            bob.open_long(targeted_long, None, None).await?;
+
+            // Three things should be true after opening the long:
+            //
+            // 1. The pool's spot price is under the max spot price prior to
+            //    considering fees
+            // 2. The pool's solvency is above zero.
+            // 3. Bob's budget is consumed.
+            let is_under_max_price = max_spot_price > spot_price_after_long;
+            let is_solvent = {
+                let state = bob.get_state().await?;
+                let error_tolerance = fixed!(1e5);
+                state.get_solvency() > error_tolerance
+            };
+            let is_budget_consumed = {
+                let error_tolerance = fixed!(1e5);
+                bob.base() < error_tolerance
+            };
+            assert!(
+                is_under_max_price && is_solvent && is_budget_consumed,
+                "Invalid targeted long."
+            );
+
+            // Claire opens a targeted long.
+            let max_spot_price = claire.get_state().await?.get_max_spot_price();
+            let target_rate = fixed_rate - fixed!(0.1e18); // Claire can afford this rate
+            let targeted_long = claire.get_targeted_long(target_rate, None).await?;
+            let spot_price_after_long = claire
+                .get_state()
+                .await?
+                .get_spot_price_after_long(targeted_long);
+            claire.open_long(targeted_long, None, None).await?;
+
+            // Four things should be true after opening the long:
+            //
+            // 1. The pool's spot price is under the max spot price prior to
+            //    considering fees
+            // 2. The pool's solvency is above zero.
+            // 3. Claire's budget is not consumed.
+            // 4. The spot rate is close to the target rate
+            let is_under_max_price = max_spot_price > spot_price_after_long;
+            let is_solvent = {
+                let state = claire.get_state().await?;
+                let error_tolerance = fixed!(1e5);
+                state.get_solvency() > error_tolerance
+            };
+            let is_budget_consumed = {
+                let error_tolerance = fixed!(1e18);
+                claire.base() > error_tolerance
+            };
+            let does_target_match_spot_rate = {
+                let state = claire.get_state().await?;
+                let fixed_rate = state.get_spot_rate();
+                let error_tolerance = fixed!(1e18);
+                if fixed_rate > target_rate {
+                    fixed_rate - target_rate < error_tolerance
+                } else {
+                    target_rate - fixed_rate < error_tolerance
+                }
+            };
+            assert!(
+                is_under_max_price
+                    && is_solvent
+                    && is_budget_consumed
+                    && does_target_match_spot_rate,
+                "Invalid targeted long."
+            );
+
+            // Revert to the snapshot and reset the agent's wallets.
+            chain.revert(id).await?;
+            alice.reset(Default::default());
+            bob.reset(Default::default());
+            claire.reset(Default::default());
+        }
+
+        Ok(())
+    }
+}

--- a/crates/hyperdrive-math/src/long/targeted.rs
+++ b/crates/hyperdrive-math/src/long/targeted.rs
@@ -27,7 +27,7 @@ impl State {
         }
     }
 
-    /// Gets a target long that can be opened given a desired fixed rate.
+    /// Gets a target long that can be opened to achieve a desired fixed rate.
     fn get_targeted_long<F: Into<FixedPoint>, I: Into<I256>>(
         &self,
         target_rate: F,
@@ -49,25 +49,25 @@ impl State {
             self.trade_deltas_from_reserves(target_share_reserves, target_bond_reserves);
 
         // Determine what rate was achieved.
-        let resulting_rate = self.rate_after_long(target_base_delta, Some(target_bond_delta)); // ERROR in here
+        let resulting_rate = self.rate_after_long(target_base_delta, Some(target_bond_delta));
 
-        let abs_rate_error = self.absolute_difference(target_rate, resulting_rate);
+        // The estimated long should always underestimate because the realized price
+        // should always be greater than the spot price.
+        if target_rate > resulting_rate {
+            return Err(eyre!("get_targeted_long: We overshot the zero-crossing.",));
+        }
+        let rate_error = resulting_rate - target_rate;
+
         // Verify solvency and target rate.
         if self
             .solvency_after_long(target_base_delta, target_bond_delta, checkpoint_exposure)
             .is_some()
-            && abs_rate_error < allowable_error
+            && rate_error < allowable_error
         {
             return Ok(target_base_delta);
         } else {
-            // Choose a first guess
-            let mut possible_target_base_delta = if resulting_rate > target_rate {
-                // undershot; use it as our first guess
-                target_base_delta
-            } else {
-                // overshot; use the minimum amount to be safe
-                self.minimum_transaction_amount() // TODO: Base or bonds or shares? probably base.
-            };
+            // We can use the initial guess as a starting point since we know it is less than the target.
+            let mut possible_target_base_delta = target_base_delta;
 
             // Iteratively find a solution
             for _ in 0..maybe_max_iterations.unwrap_or(7) {
@@ -76,7 +76,15 @@ impl State {
                     .unwrap();
                 let resulting_rate = self
                     .rate_after_long(possible_target_base_delta, Some(possible_target_bond_delta));
-                let abs_rate_error = self.absolute_difference(target_rate, resulting_rate);
+
+                // We assume that the loss is positive only because Newton's
+                // method and the one-shot approximation will always underestimate.
+                if target_rate > resulting_rate {
+                    return Err(eyre!("get_targeted_long: We overshot the zero-crossing.",));
+                }
+                // The loss is $l(x) = r(x) - r_t$ for some rate after a long
+                // is opened, $r(x)$, and target rate, $r_t$.
+                let loss = resulting_rate - target_rate;
 
                 // If we've done it (solvent & within error), then return the value.
                 if self
@@ -86,15 +94,18 @@ impl State {
                         checkpoint_exposure,
                     )
                     .is_some()
-                    && abs_rate_error < allowable_error
+                    && loss < allowable_error
                 {
                     return Ok(possible_target_base_delta);
 
                 // Otherwise perform another iteration.
                 } else {
-                    let negative_loss_derivative = match self.negative_targeted_loss_derivative(
+                    // The derivative of the loss is $l'(x) = r'(x)$.
+                    // We return $-l'(x)$ because $r'(x)$ is negative, which
+                    // can't be represented with FixedPoint.
+                    let negative_loss_derivative = match self.negative_rate_after_long_derivative(
                         possible_target_base_delta,
-                        Some(possible_target_bond_delta),
+                        possible_target_bond_delta,
                     ) {
                         Some(derivative) => derivative,
                         None => {
@@ -103,20 +114,17 @@ impl State {
                         ));
                         }
                     };
-                    let loss = self.targeted_loss(
-                        target_rate,
-                        possible_target_base_delta,
-                        Some(possible_target_bond_delta),
-                    );
 
-                    // adding the negative loss derivative instead of subtracting the loss derivative
+                    // Adding the negative loss derivative instead of subtracting the loss derivative
+                    // ∆x_{n+1} = ∆x_{n} - l / l'
+                    //          = ∆x_{n} + l / (-l')
                     possible_target_base_delta =
                         possible_target_base_delta + loss / negative_loss_derivative;
                 }
             }
 
-            // If we hit max iterations and never were within error, check solvency & return.
-            if self
+            // Final solvency check.
+            if !self
                 .solvency_after_long(
                     possible_target_base_delta,
                     self.calculate_open_long(possible_target_base_delta)
@@ -125,27 +133,42 @@ impl State {
                 )
                 .is_some()
             {
-                return Ok(possible_target_base_delta);
-
-            // Otherwise we'll return an error.
-            } else {
-                return Err(eyre!("Initial guess in `get_targeted_long` is insolvent."));
+                return Err(eyre!("Guess in `get_targeted_long` is insolvent."));
             }
+
+            // Final accuracy check.
+            let possible_target_bond_delta = self
+                .calculate_open_long(possible_target_base_delta)
+                .unwrap();
+            let resulting_rate =
+                self.rate_after_long(possible_target_base_delta, Some(possible_target_bond_delta));
+            if target_rate > resulting_rate {
+                return Err(eyre!("get_targeted_long: We overshot the zero-crossing.",));
+            }
+            let loss = resulting_rate - target_rate;
+            if !(loss < allowable_error) {
+                return Err(eyre!(
+                    "get_targeted_long: Unable to find an acceptible loss. Final loss = {}.",
+                    loss
+                ));
+            }
+
+            Ok(possible_target_base_delta)
         }
     }
 
-    /// The non-negative difference between two values
-    /// TODO: Add docs
-    fn absolute_difference(&self, x: FixedPoint, y: FixedPoint) -> FixedPoint {
-        if y > x {
-            y - x
-        } else {
-            x - y
-        }
-    }
-
-    /// The spot fixed rate after a long has been opened
-    /// TODO: Add docs
+    /// The fixed rate after a long has been opened.
+    ///
+    /// We calculate the rate for a fixed length of time as:
+    /// $$
+    /// r(x) = (1 - p(x)) / (p(x) t)
+    /// $$
+    ///
+    /// where $p(x)$ is the spot price after a long for `delta_bonds`$= x$ and
+    /// t is the normalized position druation.
+    ///
+    /// In this case, we use the resulting spot price after a hypothetical long
+    /// for `base_amount` is opened.
     fn rate_after_long(
         &self,
         base_amount: FixedPoint,
@@ -157,63 +180,109 @@ impl State {
         (fixed!(1e18) - resulting_price) / (resulting_price * annualized_time)
     }
 
-    /// The derivative of the equation for calculating the spot rate after a long
-    /// TODO: Add docs
+    /// The derivative of the equation for calculating the rate after a long.
+    ///
+    /// For some $r = (1 - p(x)) / (p(x) * t)$, where $p(x)$
+    /// is the spot price after a long of `delta_base`$= x$ was opened and $t$
+    /// is the annualized position duration, the rate derivative is:
+    ///
+    /// $$
+    /// r'(x) = \frac{(-p'(x) p(x) t - (1 - p(x)) (p'(x) t))}{(p(x) t)^2} //
+    /// r'(x) = \frac{-p'(x)}{t p(x)^2}
+    /// $$
+    ///
+    /// We return $-r'(x)$ because negative numbers cannot be represented by FixedPoint.
     fn negative_rate_after_long_derivative(
         &self,
         base_amount: FixedPoint,
-        bond_amount: Option<FixedPoint>,
+        bond_amount: FixedPoint,
     ) -> Option<FixedPoint> {
         let annualized_time =
             self.position_duration() / FixedPoint::from(U256::from(60 * 60 * 24 * 365));
-        let price = self.get_spot_price_after_long(base_amount, bond_amount);
+        let price = self.get_spot_price_after_long(base_amount, Some(bond_amount));
         let price_derivative = match self.price_after_long_derivative(base_amount, bond_amount) {
             Some(derivative) => derivative,
             None => return None,
         };
-
-        // The actual equation we want to solve is:
-        // (-p' * p * d - (1-p) (p'd + p)) / (p * d)^2
+        // The actual equation we want to represent is:
+        // r' = -p' / (t p^2)
         // We can do a trick to return a positive-only version and
         // indicate that it should be negative in the fn name.
-        // -1 * -1 * (-p' * p * d - (1-p) (p'*d + p)) / (p * d)^2
-        // -1 * (p' * p * d + (1-p) (p'*d + p)) / (p * d)^2
-        Some(
-            (price_derivative * price * annualized_time
-                + (fixed!(1e18) - price) * (price_derivative * annualized_time + price))
-                / (price * annualized_time).pow(fixed!(2e18)),
-        )
+        Some(price_derivative / (annualized_time * price.pow(fixed!(2e18))))
     }
 
-    /// The derivative of the price after a long
-    /// TODO: Add docs
+    /// The derivative of the price after a long.
+    ///
+    /// The price after a long that moves shares by $\Delta z$ and bonds by $\Delta y$
+    /// is equal to $P(\Delta z) = \frac{\mu (z_e + \Delta z)}{y - \Delta y}^T$,
+    /// where $T$ is the time stretch constant and $z_e$ is the initial effective share reserves.
+    /// Equivalently, for some amount of `delta_base`$= x$ provided to open a long,
+    /// we can write:
+    ///
+    /// $$
+    /// p(x) = \frac{\mu (z_e + \frac{x}{c} - g(x) - \zeta)}{y_0 - Y(x)}^{T}
+    /// $$
+    /// where $g(x)$ is the [open_long_governance_fee](long::fees::open_long_governance_fee),
+    /// $Y(x)$ is the [long_amount](long::open::calculate_open_long), and $\zeta$ is the
+    /// zeta adjustment.
+    ///
+    /// To compute the derivative, we first define some auxiliary variables:
+    /// $$
+    /// a(x) = \mu (z_e + \frac{x}{c} - g(x) - \zeta) \\
+    /// b(x) = y_0 - Y(x) \\
+    /// v(x) = \frac{a(x)}{b(x)}
+    /// $$
+    ///
+    /// and thus $p(x) = v(x)^T$. Given these, we can write out intermediate derivatives:
+    ///
+    /// $$
+    /// a'(x) = \frac{\mu}{c} - g'(x) \\
+    /// b'(x) = -Y'(x) \\
+    /// v'(x) = \frac{b a' - a b'}{b^2}
+    /// $$
+    ///
+    /// And finally, the price after long derivative is:
+    ///
+    /// $$
+    /// p'(x) = v'(x) T v(x)^(T-1)
+    /// $$
+    ///
     fn price_after_long_derivative(
         &self,
         base_amount: FixedPoint,
-        bond_amount: Option<FixedPoint>,
+        bond_amount: FixedPoint,
     ) -> Option<FixedPoint> {
-        let bond_amount = match bond_amount {
-            Some(bond_amount) => bond_amount,
-            None => self.calculate_open_long(base_amount).unwrap(),
-        };
-        let long_amount_derivative = match self.long_amount_derivative(base_amount) {
-            Some(derivative) => derivative,
-            None => return None,
-        };
-        let initial_spot_price = self.get_spot_price();
+        // g'(x)
         let gov_fee_derivative =
-            self.governance_lp_fee() * self.curve_fee() * (fixed!(1e18) - initial_spot_price);
+            self.governance_lp_fee() * self.curve_fee() * (fixed!(1e18) - self.get_spot_price());
+
+        // a(x) = u (z_e + x/c - g(x) - zeta)
         let inner_numerator = self.mu()
             * (self.ze() + base_amount / self.vault_share_price()
                 - self.open_long_governance_fee(base_amount)
                 - self.zeta().into());
+
+        // a'(x) = u / c - g'(x)
         let inner_numerator_derivative = self.mu() / self.vault_share_price() - gov_fee_derivative;
+
+        // b(x) = y_0 - Y(x)
         let inner_denominator = self.bond_reserves() - bond_amount;
 
+        // b'(x) = Y'(x)
+        let long_amount_derivative = match self.long_amount_derivative(base_amount) {
+            Some(derivative) => derivative,
+            None => return None,
+        };
+
+        // v(x) = a(x) / b(x)
+        // v'(x) = ( b(x) * a'(x) + a(x) * b'(x) ) / b(x)^2
         let inner_derivative = (inner_denominator * inner_numerator_derivative
             + inner_numerator * long_amount_derivative)
             / inner_denominator.pow(fixed!(2e18));
-        // Second quotient is flipped (denominator / numerator) to avoid negative exponent
+
+        // p'(x) = v'(x) T v(x)^(T-1)
+        // p'(x) = v'(x) T v(x)^(-1)^(1-T)
+        // v(x) is flipped to (denominator / numerator) to avoid a negative exponent
         return Some(
             inner_derivative
                 * self.time_stretch()
@@ -221,91 +290,86 @@ impl State {
         );
     }
 
-    /// The loss used for the targeted long optimization process
-    /// TODO: Add docs
-    fn targeted_loss(
-        &self,
-        target_rate: FixedPoint,
-        base_amount: FixedPoint,
-        bond_amount: Option<FixedPoint>,
-    ) -> FixedPoint {
-        let resulting_rate = self.rate_after_long(base_amount, bond_amount);
-        // This should never happen, but jic
-        if target_rate > resulting_rate {
-            panic!("We overshot the zero-crossing!");
-        }
-        resulting_rate - target_rate
-    }
-
-    /// Derivative of the targeted long loss
-    /// TODO: Add docs
-    fn negative_targeted_loss_derivative(
-        &self,
-        base_amount: FixedPoint,
-        bond_amount: Option<FixedPoint>,
-    ) -> Option<FixedPoint> {
-        match self.negative_rate_after_long_derivative(base_amount, bond_amount) {
-            Some(derivative) => return Some(derivative),
-            None => return None,
-        }
-    }
-
-    /// Calculate the base & bond deltas from the current state given desired new reserve levels
-    /// TODO: Add docs
+    /// Calculate the base & bond deltas from the current state given desired new reserve levels.
+    ///
+    /// Given a target ending pool share reserves, $z_t$, and bond reserves, $y_t$,
+    /// the trade deltas to achieve that state would be:
+    ///
+    /// $$
+    /// \Delta x = c * (z_t - z_e) \\
+    /// \Delta y = y - y_t - c(\Delta x)
+    /// $$
+    ///
+    /// where $c$ is the vault share price and
+    /// $c(\Delta x)$ is the (open_long_curve_fee)[long::fees::open_long_curve_fees].
     fn trade_deltas_from_reserves(
         &self,
         share_reserves: FixedPoint,
         bond_reserves: FixedPoint,
     ) -> (FixedPoint, FixedPoint) {
-        // The spot max base amount is given by:
-        //
-        // spot_target_base_amount = c * (z_t - z)
         let base_delta =
             (share_reserves - self.effective_share_reserves()) * self.vault_share_price();
-
-        // The spot max bond amount is given by:
-        //
-        // spot_target_bond_amount = (y - y_t) - c(x)
         let bond_delta =
             (self.bond_reserves() - bond_reserves) - self.open_long_curve_fees(base_delta);
-
         (base_delta, bond_delta)
     }
 
     /// Calculates the long that should be opened to hit a target interest rate.
-    /// This calculation does not take Hyperdrive's solvency constraints into account and shouldn't be used directly.
+    /// This calculation does not take Hyperdrive's solvency constraints or exposure
+    /// into account and shouldn't be used directly.
+    ///
+    /// The price for a given fixed-rate is given by $p = 1 / (r t + 1)$, where
+    /// $r$ is the fixed-rate and $t$ is the annualized position duration. The
+    /// price for a given pool reserves is given by $p = \frac{\mu z}{y}^T$,
+    /// where $\mu$ is the initial share price and $T$ is the time stretch
+    /// constant. By setting these equal we can solve for the pool reserve levels
+    /// as a function of a target rate.
+    ///
+    /// For some target rate, $r_t$, the pool share reserves, $z_t$, must be:
+    ///
+    /// $$
+    /// z_t = \frac{1}{\mu} \left(
+    ///   \frac{k}{\frac{c}{\mu} + \left(
+    ///     (r_t t + 1)^{\frac{1}{T}}
+    ///   \right)^{1 - T}}
+    /// \right)^{\tfrac{1}{1 - T}}
+    /// $$
+    ///
+    /// and the pool bond reserves, $y_t$, must be:
+    ///
+    /// $$
+    /// y_t = \left(
+    ///   \frac{k}{ \frac{c}{\mu} +  \left(
+    ///     \left( r_t t + 1 \right)^{\frac{1}{T}}
+    ///   \right)^{1-T}}
+    /// \right)^{1-T} \left( r_t t + 1 \right)^{\frac{1}{T}}
+    /// $$
     fn reserves_given_rate_ignoring_exposure<F: Into<FixedPoint>>(
         &self,
         target_rate: F,
     ) -> (FixedPoint, FixedPoint) {
-        //
-        // TODO: Docstring
-        //
         let target_rate = target_rate.into();
         let annualized_time =
             self.position_duration() / FixedPoint::from(U256::from(60 * 60 * 24 * 365));
+
+        // First get the target share reserves
         let c_over_mu = self
             .vault_share_price()
             .div_up(self.initial_vault_share_price());
         let scaled_rate = (target_rate.mul_up(annualized_time) + fixed!(1e18))
             .pow(fixed!(1e18) / self.time_stretch());
-        let inner = (self.k_down()
+        let target_base_reserves = (self.k_down()
             / (c_over_mu + scaled_rate.pow(fixed!(1e18) - self.time_stretch())))
         .pow(fixed!(1e18) / (fixed!(1e18) - self.time_stretch()));
-        let target_share_reserves = inner / self.initial_vault_share_price();
+        let target_share_reserves = target_base_reserves / self.initial_vault_share_price();
 
-        // Now that we have the target share reserves, we can calculate the
-        // target bond reserves using the formula:
-        //
-        // TODO: docstring
-        //
-        let target_bond_reserves = inner * scaled_rate;
+        // Then get the target bond reserves.
+        let target_bond_reserves = target_base_reserves * scaled_rate;
 
         (target_share_reserves, target_bond_reserves)
     }
 }
 
-// TODO: Modify this test to use mock for state updates
 #[cfg(test)]
 mod tests {
     use eyre::Result;
@@ -313,17 +377,11 @@ mod tests {
     use test_utils::{
         agent::Agent,
         chain::{Chain, TestChain},
-        constants::FAST_FUZZ_RUNS,
+        constants::FUZZ_RUNS,
     };
     use tracing_test::traced_test;
 
     use super::*;
-
-    // TODO:
-    // #[traced_test]
-    // #[tokio::test]
-    // async fn test_reserves_given_rate_ignoring_solvency() -> Result<()> {
-    // }
 
     #[traced_test]
     #[tokio::test]
@@ -336,16 +394,16 @@ mod tests {
 
         let allowable_solvency_error = fixed!(1e5);
         let allowable_budget_error = fixed!(1e5);
-        let allowable_rate_error = fixed!(1e14);
-        let num_newton_iters = 7;
+        let allowable_rate_error = fixed!(1e10);
+        let num_newton_iters = 3;
 
         // Initialize a test chain; don't need mocks because we want state updates.
         let chain = TestChain::new(2).await?;
 
-        // Grab accounts for Alice, Bob, and Claire.
+        // Grab accounts for Alice and Bob.
         let (alice, bob) = (chain.accounts()[0].clone(), chain.accounts()[1].clone());
 
-        // Initialize Alice, Bob, and Claire as Agents.
+        // Initialize Alice and Bob as Agents.
         let mut alice =
             Agent::new(chain.client(alice).await?, chain.addresses().clone(), None).await?;
         let mut bob = Agent::new(chain.client(bob).await?, chain.addresses(), None).await?;
@@ -353,7 +411,7 @@ mod tests {
 
         // Fuzz test
         let mut rng = thread_rng();
-        for _ in 0..*FAST_FUZZ_RUNS {
+        for _ in 0..*FUZZ_RUNS {
             // Snapshot the chain.
             let id = chain.snapshot().await?;
 
@@ -398,34 +456,49 @@ mod tests {
             // 1. The pool's spot price is under the max spot price prior to
             //    considering fees
             // 2. The pool's solvency is above zero.
-            // 3. IF Bob's budget is not consumed; then new rate is the target rate
+            // 3. IF Bob's budget is not consumed; then new rate is close to the target rate
+
+            // Check that our resulting price is under the max
             let spot_price_after_long = bob.get_state().await?.get_spot_price();
-            let is_under_max_price = max_spot_price_before_long > spot_price_after_long;
+            assert!(
+                max_spot_price_before_long > spot_price_after_long,
+                "Resulting price is greater than the max."
+            );
+
+            // Check solvency
             let is_solvent = {
                 let state = bob.get_state().await?;
                 state.get_solvency() > allowable_solvency_error
             };
-            assert!(
-                is_under_max_price,
-                "Invalid targeted long: Resulting price is greater than the max."
-            );
-            assert!(
-                is_solvent,
-                "Invalid targeted long: Resulting pool state is not solvent."
-            );
+            assert!(is_solvent, "Resulting pool state is not solvent.");
 
+            // If the budget was NOT consumed, then we assume the target was hit.
             let new_rate = bob.get_state().await?.get_spot_rate();
-            let is_budget_consumed = bob.base() < allowable_budget_error;
-            let is_rate_achieved = if new_rate > target_rate {
-                new_rate - target_rate < allowable_rate_error
-            } else {
-                target_rate - new_rate < allowable_rate_error
-            };
-            if !is_budget_consumed {
+            if !(bob.base() <= allowable_budget_error) {
+                // Actual price might result in long overshooting the target.
+                let abs_error = if target_rate > new_rate {
+                    target_rate - new_rate
+                } else {
+                    new_rate - target_rate
+                };
                 assert!(
-                    is_rate_achieved,
-                    "Invalid targeted long: target_rate was {}, realized rate is {}.",
-                    target_rate, new_rate
+                    abs_error <= allowable_rate_error,
+                    "target_rate was {}, realized rate is {}. abs_error={} was not <= {}.",
+                    target_rate,
+                    new_rate,
+                    abs_error,
+                    allowable_rate_error
+                );
+
+            // Else, we should have undershot,
+            // or by some coincidence the budget was the perfect amount
+            // and we hit the rate exactly.
+            } else {
+                assert!(
+                    new_rate <= target_rate,
+                    "The new_rate={} should be <= target_rate={} when budget constrained.",
+                    new_rate,
+                    target_rate
                 );
             }
 

--- a/crates/hyperdrive-math/src/long/targeted.rs
+++ b/crates/hyperdrive-math/src/long/targeted.rs
@@ -7,13 +7,18 @@ use crate::{State, YieldSpace};
 
 impl State {
     /// Gets a target long that can be opened given a budget to achieve a desired fixed rate.
-    pub fn get_targeted_long_with_budget<F: Into<FixedPoint>, I: Into<I256>>(
+    pub fn get_targeted_long_with_budget<
+        F1: Into<FixedPoint>,
+        F2: Into<FixedPoint>,
+        F3: Into<FixedPoint>,
+        I: Into<I256>,
+    >(
         &self,
-        budget: F,
-        target_rate: F,
+        budget: F1,
+        target_rate: F2,
         checkpoint_exposure: I,
         maybe_max_iterations: Option<usize>,
-        maybe_allowable_error: Option<F>,
+        maybe_allowable_error: Option<F3>,
     ) -> Result<FixedPoint> {
         let budget = budget.into();
         match self.get_targeted_long(
@@ -28,12 +33,12 @@ impl State {
     }
 
     /// Gets a target long that can be opened to achieve a desired fixed rate.
-    fn get_targeted_long<F: Into<FixedPoint>, I: Into<I256>>(
+    fn get_targeted_long<F1: Into<FixedPoint>, F2: Into<FixedPoint>, I: Into<I256>>(
         &self,
-        target_rate: F,
+        target_rate: F1,
         checkpoint_exposure: I,
         maybe_max_iterations: Option<usize>,
-        maybe_allowable_error: Option<F>,
+        maybe_allowable_error: Option<F2>,
     ) -> Result<FixedPoint> {
         let target_rate = target_rate.into();
         let checkpoint_exposure = checkpoint_exposure.into();

--- a/crates/hyperdrive-math/src/long/targeted.rs
+++ b/crates/hyperdrive-math/src/long/targeted.rs
@@ -108,7 +108,7 @@ impl State {
                     // The derivative of the loss is $l'(x) = r'(x)$.
                     // We return $-l'(x)$ because $r'(x)$ is negative, which
                     // can't be represented with FixedPoint.
-                    let negative_loss_derivative = match self.negative_rate_after_long_derivative(
+                    let negative_loss_derivative = match self.rate_after_long_derivative_negation(
                         possible_target_base_delta,
                         possible_target_bond_delta,
                     ) {
@@ -197,7 +197,7 @@ impl State {
     /// $$
     ///
     /// We return $-r'(x)$ because negative numbers cannot be represented by FixedPoint.
-    fn negative_rate_after_long_derivative(
+    fn rate_after_long_derivative_negation(
         &self,
         base_amount: FixedPoint,
         bond_amount: FixedPoint,
@@ -319,7 +319,7 @@ impl State {
         (base_delta, bond_delta)
     }
 
-    /// Calculates the long that should be opened to hit a target interest rate.
+    /// Calculates the pool reserve levels to achieve a target interest rate.
     /// This calculation does not take Hyperdrive's solvency constraints or exposure
     /// into account and shouldn't be used directly.
     ///

--- a/crates/hyperdrive-math/tests/integration_tests.rs
+++ b/crates/hyperdrive-math/tests/integration_tests.rs
@@ -216,7 +216,7 @@ pub async fn test_integration_calculate_max_long() -> Result<()> {
         let spot_price_after_long = bob
             .get_state()
             .await?
-            .calculate_spot_price_after_long(max_long, None);
+            .calculate_spot_price_after_long(max_long, None)?;
         bob.open_long(max_long, None, None).await?;
         let is_max_price = max_spot_price - spot_price_after_long < fixed!(1e15);
         let is_solvency_consumed = {

--- a/crates/test-utils/src/agent.rs
+++ b/crates/test-utils/src/agent.rs
@@ -937,7 +937,7 @@ impl Agent<ChainClient, ChaCha8Rng> {
     /// with the current market state.
     pub async fn calculate_open_long(&self, base_amount: FixedPoint) -> Result<FixedPoint> {
         let state = self.get_state().await?;
-        Ok(state.calculate_open_long(base_amount))
+        state.calculate_open_long(base_amount)
     }
 
     /// Calculates the deposit required to short a given amount of bonds with the
@@ -979,12 +979,14 @@ impl Agent<ChainClient, ChaCha8Rng> {
             .hyperdrive
             .get_checkpoint_exposure(state.to_checkpoint(self.now().await?))
             .await?;
-        Ok(state.get_targeted_long(
-            self.wallet.base,
-            target_rate,
-            checkpoint_exposure,
-            maybe_max_iterations,
-        ))
+        Ok(state
+            .get_targeted_long_with_budget(
+                self.wallet.base,
+                target_rate,
+                checkpoint_exposure,
+                maybe_max_iterations,
+            )
+            .unwrap())
     }
 
     /// Calculates the max short that can be opened in the current checkpoint.

--- a/crates/test-utils/src/agent.rs
+++ b/crates/test-utils/src/agent.rs
@@ -4,7 +4,7 @@ use ethers::{
     abi::Detokenize,
     contract::ContractCall,
     prelude::EthLogDecode,
-    providers::{Http, Middleware, Provider, RetryClient},
+    providers::{maybe, Http, Middleware, Provider, RetryClient},
     types::{Address, BlockId, I256, U256},
 };
 use eyre::Result;
@@ -973,6 +973,7 @@ impl Agent<ChainClient, ChaCha8Rng> {
         &self,
         target_rate: FixedPoint,
         maybe_max_iterations: Option<usize>,
+        maybe_allowable_error: Option<FixedPoint>,
     ) -> Result<FixedPoint> {
         let state = self.get_state().await?;
         let checkpoint_exposure = self
@@ -985,6 +986,7 @@ impl Agent<ChainClient, ChaCha8Rng> {
                 target_rate,
                 checkpoint_exposure,
                 maybe_max_iterations,
+                maybe_allowable_error,
             )
             .unwrap())
     }

--- a/crates/test-utils/src/agent.rs
+++ b/crates/test-utils/src/agent.rs
@@ -969,7 +969,7 @@ impl Agent<ChainClient, ChaCha8Rng> {
     }
 
     /// Gets the long that moves the fixed rate to a target value.
-    pub async fn get_targeted_long(
+    pub async fn calculate_targeted_long(
         &self,
         target_rate: FixedPoint,
         maybe_max_iterations: Option<usize>,
@@ -981,7 +981,7 @@ impl Agent<ChainClient, ChaCha8Rng> {
             .get_checkpoint_exposure(state.to_checkpoint(self.now().await?))
             .await?;
         Ok(state
-            .get_targeted_long_with_budget(
+            .calculate_targeted_long_with_budget(
                 self.wallet.base,
                 target_rate,
                 checkpoint_exposure,

--- a/crates/test-utils/src/agent.rs
+++ b/crates/test-utils/src/agent.rs
@@ -4,7 +4,7 @@ use ethers::{
     abi::Detokenize,
     contract::ContractCall,
     prelude::EthLogDecode,
-    providers::{maybe, Http, Middleware, Provider, RetryClient},
+    providers::{Http, Middleware, Provider, RetryClient},
     types::{Address, BlockId, I256, U256},
 };
 use eyre::Result;

--- a/crates/test-utils/src/agent.rs
+++ b/crates/test-utils/src/agent.rs
@@ -968,6 +968,25 @@ impl Agent<ChainClient, ChaCha8Rng> {
         Ok(state.calculate_max_long(self.wallet.base, checkpoint_exposure, maybe_max_iterations))
     }
 
+    /// Gets the long that moves the fixed rate to a target value.
+    pub async fn get_targeted_long(
+        &self,
+        target_rate: FixedPoint,
+        maybe_max_iterations: Option<usize>,
+    ) -> Result<FixedPoint> {
+        let state = self.get_state().await?;
+        let checkpoint_exposure = self
+            .hyperdrive
+            .get_checkpoint_exposure(state.to_checkpoint(self.now().await?))
+            .await?;
+        Ok(state.get_targeted_long(
+            self.wallet.base,
+            target_rate,
+            checkpoint_exposure,
+            maybe_max_iterations,
+        ))
+    }
+
     /// Calculates the max short that can be opened in the current checkpoint.
     ///
     /// Since interest can accrue between the time the calculation is made and


### PR DESCRIPTION
addresses https://github.com/delvtech/hyperdrive/issues/775

The solution first attempts to directly compute targeted reserve levels:
For some target rate, $r_t$, the pool share reserves, $z_t$, must be:

$$
z_t = \frac{1}{\mu} \left(
  \frac{k}{\frac{c}{\mu} + \left(
    (r_t t + 1)^{\frac{1}{T}}
  \right)^{1 - T}}
\right)^{\tfrac{1}{1 - T}}
$$

and the pool bond reserves, $y_t$, must be:

$$
y_t = \left(
  \frac{k}{ \frac{c}{\mu} +  \left(
    \left( r_t t + 1 \right)^{\frac{1}{T}}
  \right)^{1-T}}
\right)^{1-T} \left( r_t t + 1 \right)^{\frac{1}{T}}
$$

where $c$ is the vault share price, $\mu$ is the initial vault share price, $t$ is the annualized position duration, and $T$ is the time stretch constant. The corresponding deltas are then:

$$
\Delta x = c * (z_t - z_e)
$$

$$
\Delta y = y - y_t - c(\Delta x)
$$

If that is not successful, then it performs newtons method to minimize

$$
l(x) = r(x) - r_t
$$

for some realized fixed rate, $r(x) = (1 - p(x)) / (p(x) t)$ after a long was opened with $x$ base, where $p(x)$ is the spot price after the long was opened.