### PR TITLE
Updated the CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,4 @@
 # All PRs must be approved by code owners
 * @jalextowle @jrhea
+contracts/* @mcclurejt
+crates/* @dpaiton @mcclurejt

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,10 @@
-# All PRs must be approved by code owners
-* @jalextowle @jrhea
-contracts/* @mcclurejt
-crates/* @dpaiton @mcclurejt
+# Global Code Owners
+* @jalextowle @jrhea @mcclurejt
+
+# Rust SDK Code Owners
+.github/* @dpaiton @slundqui @ryangoree
+crates/* @dpaiton @slundqui @ryangoree
+Cargo.toml @dpaiton @slundqui @ryangoree
+rustfmt.toml @dpaiton @slundqui @ryangoree
+Makefile @dpaiton @slundqui @ryangoree
+README.md @dpaiton @slundqui @ryangoree


### PR DESCRIPTION
# Description

This PR adds @mcclurejt as a global codeowner and @dpaiton, @slundqui, and @ryangoree as Rust SDK code owners. We have faced review bottlenecks recently, and distributing the review burden will help to alleviate these issues while maintaining a high bar to merge PRs.