### PR TITLE
Updated the codeowners file to be more permissive

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -2,9 +2,9 @@
 * @jalextowle @jrhea @mcclurejt
 
 # Rust SDK Code Owners
-.github/* @dpaiton @slundqui @ryangoree
-crates/* @dpaiton @slundqui @ryangoree
-Cargo.toml @dpaiton @slundqui @ryangoree
-rustfmt.toml @dpaiton @slundqui @ryangoree
-Makefile @dpaiton @slundqui @ryangoree
-README.md @dpaiton @slundqui @ryangoree
+.github/ @jalextowle @jrhea @mcclurejt @dpaiton @slundqui @ryangoree
+crates/ @jalextowle @jrhea @mcclurejt @dpaiton @slundqui @ryangoree
+Cargo.toml @jalextowle @jrhea @mcclurejt @dpaiton @slundqui @ryangoree
+rustfmt.toml @jalextowle @jrhea @mcclurejt @dpaiton @slundqui @ryangoree
+Makefile @jalextowle @jrhea @mcclurejt @dpaiton @slundqui @ryangoree
+README.md @jalextowle @jrhea @mcclurejt @dpaiton @slundqui @ryangoree


### PR DESCRIPTION
# Description

I noticed that @dpaiton wasn't able to approve one of my earlier PRs even though he should be a codeowner. This update makes the file more consistent with Github's example and also fixes an issue that would have prevented the global codeowners from approving changes made to the Rust SDK.