### PR TITLE
getInitialVaultSharePrice uses convertToBase logic

### DIFF
--- a/contracts/src/deployers/ezeth/EzETHHyperdriveDeployerCoordinator.sol
+++ b/contracts/src/deployers/ezeth/EzETHHyperdriveDeployerCoordinator.sol
@@ -6,7 +6,7 @@ import { SafeERC20 } from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 import { IERC20 } from "../../interfaces/IERC20.sol";
 import { IHyperdrive } from "../../interfaces/IHyperdrive.sol";
 import { IHyperdriveDeployerCoordinator } from "../../interfaces/IHyperdriveDeployerCoordinator.sol";
-import { IRestakeManager } from "../../interfaces/IRenzo.sol";
+import { IRestakeManager, IRenzoOracle } from "../../interfaces/IRenzo.sol";
 import { ETH } from "../../libraries/Constants.sol";
 import { FixedPointMath, ONE } from "../../libraries/FixedPointMath.sol";
 import { HyperdriveDeployerCoordinator } from "../HyperdriveDeployerCoordinator.sol";
@@ -23,6 +23,9 @@ contract EzETHHyperdriveDeployerCoordinator is HyperdriveDeployerCoordinator {
 
     /// @notice The Renzo contract.
     IRestakeManager public immutable restakeManager;
+
+    /// @notice The Renzo Oracle contract.
+    IRenzoOracle public immutable renzoOracle;
 
     /// @notice The ezETH token contract.
     IERC20 public immutable ezETH;
@@ -55,6 +58,7 @@ contract EzETHHyperdriveDeployerCoordinator is HyperdriveDeployerCoordinator {
     {
         restakeManager = _restakeManager;
         ezETH = IERC20(_restakeManager.ezETH());
+        renzoOracle = IRenzoOracle(restakeManager.renzoOracle());
     }
 
     /// @dev Prepares the coordinator for initialization by drawing funds from
@@ -138,11 +142,26 @@ contract EzETHHyperdriveDeployerCoordinator is HyperdriveDeployerCoordinator {
         IHyperdrive.PoolDeployConfig memory, // unused pool deploy config
         bytes memory // unused extra data
     ) internal view override returns (uint256) {
-        // Return ezETH's current vault share price.
-        (, , uint256 totalTVL) = restakeManager.calculateTVLs();
-        uint256 ezETHSupply = ezETH.totalSupply();
+        return _convertToBase(ONE);
+    }
 
-        // Price in ETH / ezETH, does not include eigenlayer points.
-        return totalTVL.divDown(ezETHSupply);
+    /// @dev Convert an amount of vault shares to an amount of base.
+    /// @param _shareAmount The vault shares amount.
+    /// @return baseAmount The base amount.
+    function _convertToBase(
+        uint256 _shareAmount
+    ) internal view returns (uint256) {
+        // Get the total TVL priced in ETH from restakeManager
+        (, , uint256 totalTVL) = restakeManager.calculateTVLs();
+
+        // Get the total supply of the ezETH token
+        uint256 totalSupply = ezETH.totalSupply();
+
+        return
+            renzoOracle.calculateRedeemAmount(
+                _shareAmount,
+                totalSupply,
+                totalTVL
+            );
     }
 }

--- a/contracts/src/deployers/ezeth/EzETHHyperdriveDeployerCoordinator.sol
+++ b/contracts/src/deployers/ezeth/EzETHHyperdriveDeployerCoordinator.sol
@@ -24,7 +24,7 @@ contract EzETHHyperdriveDeployerCoordinator is HyperdriveDeployerCoordinator {
     /// @notice The Renzo contract.
     IRestakeManager public immutable restakeManager;
 
-    /// @notice The Renzo Oracle contract.
+    /// @notice The RenzoOracle contract.
     IRenzoOracle public immutable renzoOracle;
 
     /// @notice The ezETH token contract.

--- a/contracts/src/deployers/ezeth/EzETHHyperdriveDeployerCoordinator.sol
+++ b/contracts/src/deployers/ezeth/EzETHHyperdriveDeployerCoordinator.sol
@@ -142,26 +142,12 @@ contract EzETHHyperdriveDeployerCoordinator is HyperdriveDeployerCoordinator {
         IHyperdrive.PoolDeployConfig memory, // unused pool deploy config
         bytes memory // unused extra data
     ) internal view override returns (uint256) {
-        return _convertToBase(ONE);
-    }
-
-    /// @dev Convert an amount of vault shares to an amount of base.
-    /// @param _shareAmount The vault shares amount.
-    /// @return baseAmount The base amount.
-    function _convertToBase(
-        uint256 _shareAmount
-    ) internal view returns (uint256) {
         // Get the total TVL priced in ETH from restakeManager
         (, , uint256 totalTVL) = restakeManager.calculateTVLs();
 
         // Get the total supply of the ezETH token
         uint256 totalSupply = ezETH.totalSupply();
 
-        return
-            renzoOracle.calculateRedeemAmount(
-                _shareAmount,
-                totalSupply,
-                totalTVL
-            );
+        return renzoOracle.calculateRedeemAmount(ONE, totalSupply, totalTVL);
     }
 }

--- a/contracts/src/deployers/reth/RETHHyperdriveDeployerCoordinator.sol
+++ b/contracts/src/deployers/reth/RETHHyperdriveDeployerCoordinator.sol
@@ -140,6 +140,6 @@ contract RETHHyperdriveDeployerCoordinator is HyperdriveDeployerCoordinator {
         bytes memory // unused extra data
     ) internal view override returns (uint256) {
         // Returns the value of one RETH token in ETH.
-        return rocketTokenReth.getExchangeRate();
+        return rocketTokenReth.getEthValue(ONE);
     }
 }

--- a/contracts/src/instances/ezeth/EzETHBase.sol
+++ b/contracts/src/instances/ezeth/EzETHBase.sol
@@ -19,7 +19,7 @@ abstract contract EzETHBase is HyperdriveBase {
     /// @dev The Renzo entrypoint contract.
     IRestakeManager internal immutable _restakeManager;
 
-    /// @dev The Renzo Oracle contract.
+    /// @dev The RenzoOracle contract.
     IRenzoOracle internal immutable _renzoOracle;
 
     /// @dev Error for zero total supply or total pooled ether.


### PR DESCRIPTION
# Resolved Issues
https://github.com/spearbit-audits/delv-review/issues/16

# Description
To solve this issue we make EzETHHyperdriveDeployerCoordinator's `_getInitialVaultSharePrice()` function's logic mirror that of EzETHBase's `convertToBase()` function. with a `_shareAmount` value of `ONE`, so that it matches how `HyperdriveBase`s `_pricePerVaultShare` logic.  See comparison here:

```ts
// HyperdriveBase
    /// @dev Loads the share price from the yield source.
    /// @return vaultSharePrice The current vault share price.
    function _pricePerVaultShare()
        internal
        view
        returns (uint256 vaultSharePrice)
    {
        return _convertToBase(ONE);
    }
```

```ts
// EzETHHyperdriveDeployerCoordinator
    /// @dev Gets the initial vault share price of the Hyperdrive pool.
    /// @return The initial vault share price of the Hyperdrive pool.
    function _getInitialVaultSharePrice(
        IHyperdrive.PoolDeployConfig memory, // unused pool deploy config
        bytes memory // unused extra data
    ) internal view override returns (uint256) {
        return _convertToBase(ONE);
    }

    /// @dev Convert an amount of vault shares to an amount of base.
    /// @param _shareAmount The vault shares amount.
    /// @return baseAmount The base amount.
    function _convertToBase(
        uint256 _shareAmount
    ) internal view returns (uint256) {
        // Get the total TVL priced in ETH from restakeManager
        (, , uint256 totalTVL) = restakeManager.calculateTVLs();

        // Get the total supply of the ezETH token
        uint256 totalSupply = ezETH.totalSupply();

        return
            renzoOracle.calculateRedeemAmount(
                _shareAmount,
                totalSupply,
                totalTVL
            );
    } 
 ```

```ts
// EzETHBase
    /// @dev Convert an amount of vault shares to an amount of base.
    /// @param _shareAmount The vault shares amount.
    /// @return baseAmount The base amount.
    function _convertToBase(
        uint256 _shareAmount
    ) internal view override returns (uint256) {
        // Get the total TVL priced in ETH from restakeManager
        (, , uint256 totalTVL) = _restakeManager.calculateTVLs();

        // Get the total supply of the ezETH token
        uint256 totalSupply = _vaultSharesToken.totalSupply();

        return
            _renzoOracle.calculateRedeemAmount(
                _shareAmount,
                totalSupply,
                totalTVL
            );
    }
```

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed. If there are
multiple reviewers, copy the checklists into sections titled `## [Reviewer Name]`.
If the PR doesn't touch Solidity and/or Rust, the corresponding checklist can
be removed.

## @jalextowle 

### Solidity

- [ ] **Tokens**
    - [ ] Do all `approve` calls use `forceApprove`?
    - [ ] Do all `transfer` calls use `safeTransfer`?
    - [ ] Do all `transferFrom` calls use `msg.sender` as the `from` address?
        - [ ] If not, is the function access restricted to prevent unauthorized
              token spend?
- [ ] **Low-level calls (`call`, `delegatecall`, `staticcall`, `transfer`, `send`)**
    - [ ] Is the returned `success` boolean checked to handle failed calls?
    - [ ] If using `delegatecall`, are there strict access controls on the
          addresses that can be called? It shouldn't be possible to `delegatecall`
          arbitrary addresses, so the list of possible targets should either be
          immutable or tightly controlled by an admin.
- [ ] **Reentrancy**
    - [ ] Are functions that make external calls or transfer ether marked as `nonReentrant`?
        - [ ] If not, is there documentation that explains why reentrancy is
              not a concern or how it's mitigated?
- [ ] **Gas Optimizations**
    - [ ] Is the logic as simple as possible?
    - [ ] Are the storage values that are used repeatedly cached in stack or
          memory variables?
    - [ ] If loops are used, are there guards in place to avoid out-of-gas
          issues?
- [ ] **Visibility**
    - [ ] Are all `payable` functions restricted to avoid stuck ether?
- [ ] **Math**
    - [ ] Is all of the arithmetic checked or guarded by if-statements that will
          catch underflows?
    - [ ] If `Safe` functions are altered, are potential underflows and
          overflows caught so that a failure flag can be thrown?
    - [ ] Are all of the rounding directions clearly documented?
- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?

### Rust

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?

## @mcclurejt or @jrhea 

### Solidity

- [ ] **Tokens**
    - [ ] Do all `approve` calls use `forceApprove`?
    - [ ] Do all `transfer` calls use `safeTransfer`?
    - [ ] Do all `transferFrom` calls use `msg.sender` as the `from` address?
        - [ ] If not, is the function access restricted to prevent unauthorized
              token spend?
- [ ] **Low-level calls (`call`, `delegatecall`, `staticcall`, `transfer`, `send`)**
    - [ ] Is the returned `success` boolean checked to handle failed calls?
    - [ ] If using `delegatecall`, are there strict access controls on the
          addresses that can be called? It shouldn't be possible to `delegatecall`
          arbitrary addresses, so the list of possible targets should either be
          immutable or tightly controlled by an admin.
- [ ] **Reentrancy**
    - [ ] Are functions that make external calls or transfer ether marked as `nonReentrant`?
        - [ ] If not, is there documentation that explains why reentrancy is
              not a concern or how it's mitigated?
- [ ] **Gas Optimizations**
    - [ ] Is the logic as simple as possible?
    - [ ] Are the storage values that are used repeatedly cached in stack or
          memory variables?
    - [ ] If loops are used, are there guards in place to avoid out-of-gas
          issues?
- [ ] **Visibility**
    - [ ] Are all `payable` functions restricted to avoid stuck ether?
- [ ] **Math**
    - [ ] Is all of the arithmetic checked or guarded by if-statements that will
          catch underflows?
    - [ ] If `Safe` functions are altered, are potential underflows and
          overflows caught so that a failure flag can be thrown?
    - [ ] Are all of the rounding directions clearly documented?
- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?

### Rust

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
