### PR TITLE
Add error handling to rust trade logic

### DIFF
--- a/crates/hyperdrive-math/src/long/close.rs
+++ b/crates/hyperdrive-math/src/long/close.rs
@@ -111,7 +111,11 @@ mod tests {
         let mut rng = thread_rng();
         let state = rng.gen::<State>();
         let result = std::panic::catch_unwind(|| {
-            state.calculate_close_long(state.config.minimum_transaction_amount - 10, 0.into())
+            state.calculate_close_long(
+                state.config.minimum_transaction_amount - 10,
+                0.into(),
+                0.into(),
+            )
         });
         assert!(result.is_err());
         Ok(())

--- a/crates/hyperdrive-math/src/long/close.rs
+++ b/crates/hyperdrive-math/src/long/close.rs
@@ -110,12 +110,9 @@ mod tests {
     async fn test_close_long_min_txn_amount() -> Result<()> {
         let mut rng = thread_rng();
         let state = rng.gen::<State>();
-        let result = std::panic::catch_unwind(||
-            state.calculate_close_long(
-                state.config.minimum_transaction_amount - 10,
-                0.into(),
-            )
-        );
+        let result = std::panic::catch_unwind(|| {
+            state.calculate_close_long(state.config.minimum_transaction_amount - 10, 0.into())
+        });
         assert!(result.is_err());
         Ok(())
     }

--- a/crates/hyperdrive-math/src/long/close.rs
+++ b/crates/hyperdrive-math/src/long/close.rs
@@ -104,4 +104,19 @@ mod tests {
 
         Ok(())
     }
+
+    // Tests close long with an amount smaller than the minimum.
+    #[tokio::test]
+    async fn test_close_long_min_txn_amount() -> Result<()> {
+        let mut rng = thread_rng();
+        let state = rng.gen::<State>();
+        let result = std::panic::catch_unwind(||
+            state.calculate_close_long(
+                state.config.minimum_transaction_amount - 10,
+                0.into(),
+            )
+        );
+        assert!(result.is_err());
+        Ok(())
+    }
 }

--- a/crates/hyperdrive-math/src/long/close.rs
+++ b/crates/hyperdrive-math/src/long/close.rs
@@ -41,6 +41,11 @@ impl State {
     ) -> FixedPoint {
         let bond_amount = bond_amount.into();
 
+        if bond_amount < self.config.minimum_transaction_amount.into() {
+            // TODO would be nice to return a `Result` here instead of a panic.
+            panic!("MinimumTransactionAmount: Input amount too low");
+        }
+
         // Subtract the fees from the trade
         self.calculate_close_long_flat_plus_curve(bond_amount, maturity_time, current_time)
             - self.close_long_curve_fee(bond_amount, maturity_time, current_time)

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -216,6 +216,7 @@ mod tests {
             alice.reset(Default::default());
             bob.reset(Default::default());
         }
+        Ok(())
     }
 
     // Tests open long with an amount smaller than the minimum.

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -24,13 +24,13 @@ impl State {
     /// $$
     pub fn calculate_open_long<F: Into<FixedPoint>>(&self, base_amount: F) -> FixedPoint {
         let base_amount = base_amount.into();
-        
+
         if base_amount < self.config.minimum_transaction_amount.into() {
             // TODO would be nice to return a `Result` here instead of a panic.
             panic!("MinimumTransactionAmount: Input amount too low");
         }
         // TODO do we need to check minimum share price here?
-        
+
         let long_amount =
             self.calculate_bonds_out_given_shares_in_down(base_amount / self.vault_share_price());
 

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -24,6 +24,12 @@ impl State {
     /// $$
     pub fn calculate_open_long<F: Into<FixedPoint>>(&self, base_amount: F) -> FixedPoint {
         let base_amount = base_amount.into();
+        
+        if base_amount < self.config.minimum_transaction_amount.into() {
+            // TODO would be nice to return a `Result` here instead of a panic.
+            panic!("MinimumTransactionAmount: Base amount too low");
+        }
+        
         let long_amount =
             self.calculate_bonds_out_given_shares_in_down(base_amount / self.vault_share_price());
 

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -230,16 +230,4 @@ mod tests {
         assert!(result.is_err());
         Ok(())
     }
-
-    // Tests open short with an amount larger than the maximum.
-    #[tokio::test]
-    async fn test_error_open_long_max_amount() -> Result<()> {
-        let mut rng = thread_rng();
-        let state = rng.gen::<State>();
-        let max_long_amount = state.calculate_max_long(U256::MAX, 0, Some(7));
-        let result =
-            std::panic::catch_unwind(|| state.calculate_open_long(max_long_amount + fixed!(10e18)));
-        assert!(result.is_err());
-        Ok(())
-    }
 }

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -221,7 +221,7 @@ mod tests {
 
     // Tests open long with an amount smaller than the minimum.
     #[tokio::test]
-    async fn test_open_long_min_txn_amount() -> Result<()> {
+    async fn test_error_open_long_min_txn_amount() -> Result<()> {
         let mut rng = thread_rng();
         let state = rng.gen::<State>();
         let result = std::panic::catch_unwind(|| {
@@ -233,7 +233,7 @@ mod tests {
 
     // Tests open short with an amount larger than the maximum.
     #[tokio::test]
-    async fn test_open_long_max_amount() -> Result<()> {
+    async fn test_error_open_long_max_amount() -> Result<()> {
         let mut rng = thread_rng();
         let state = rng.gen::<State>();
         let max_long_amount = state.calculate_max_long(U256::MAX, 0, Some(7));

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -229,4 +229,16 @@ mod tests {
         assert!(result.is_err());
         Ok(())
     }
+
+    // TODO ideally we would test calculate open long with an amount larger than the maximum size.
+    // However, `calculate_max_long` requires a `checkpoint_exposure` argument, which requires
+    // implementing checkpointing in the rust sdk.
+    // https://github.com/delvtech/hyperdrive/issues/862
+
+    // TODO ideally we would add a solidity fuzz test that tests `calculate_open_long` against
+    // opening longs in solidity, where we attempt to trade outside of expected values (so that
+    // we can also test error parities as well). However, the current test chain only exposes
+    // the underlying hyperdrive math functions, which doesn't take into account fees and negative
+    // interest checks.
+    // https://github.com/delvtech/hyperdrive/issues/937
 }

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -156,6 +156,68 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn fuzz_calculate_spot_rate_after_long() -> Result<()> {
+        // Spawn a test chain and create two agents -- Alice and Bob. Alice
+        // is funded with a large amount of capital so that she can initialize
+        // the pool. Bob is funded with a small amount of capital so that we
+        // can test opening a long and verify that the ending spot rate is what
+        // we expect.
+        let mut rng = thread_rng();
+        let chain = TestChain::new(2).await?;
+        let (alice, bob) = (chain.accounts()[0].clone(), chain.accounts()[1].clone());
+        let mut alice =
+            Agent::new(chain.client(alice).await?, chain.addresses().clone(), None).await?;
+        let mut bob = Agent::new(chain.client(bob).await?, chain.addresses(), None).await?;
+
+        for _ in 0..*FUZZ_RUNS {
+            // Snapshot the chain.
+            let id = chain.snapshot().await?;
+
+            // Fund Alice and Bob.
+            let fixed_rate = rng.gen_range(fixed!(0.01e18)..=fixed!(0.1e18));
+            let contribution = rng.gen_range(fixed!(10_000e18)..=fixed!(500_000_000e18));
+            let budget = rng.gen_range(fixed!(10e18)..=fixed!(500_000_000e18));
+            alice.fund(contribution).await?;
+            bob.fund(budget).await?;
+
+            // Alice initializes the pool.
+            alice.initialize(fixed_rate, contribution, None).await?;
+
+            // Attempt to predict the spot price after opening a long.
+            let base_paid = rng.gen_range(fixed!(0.1e18)..=bob.calculate_max_long(None).await?);
+            let expected_spot_rate = bob
+                .get_state()
+                .await?
+                .calculate_spot_rate_after_long(base_paid, None);
+
+            // Open the long.
+            bob.open_long(base_paid, None, None).await?;
+
+            // Verify that the predicted spot rate is equal to the ending spot
+            // rate. These won't be exactly equal because the vault share price
+            // increases between the prediction and opening the long.
+            let actual_spot_rate = bob.get_state().await?.calculate_spot_rate();
+            let delta = if actual_spot_rate > expected_spot_rate {
+                actual_spot_rate - expected_spot_rate
+            } else {
+                expected_spot_rate - actual_spot_rate
+            };
+            let tolerance = fixed!(1e9);
+            assert!(
+                delta < tolerance,
+                "expected: delta = {} < {} = tolerance",
+                delta,
+                tolerance
+            );
+
+            // Revert to the snapshot and reset the agent's wallets.
+            chain.revert(id).await?;
+            alice.reset(Default::default());
+            bob.reset(Default::default());
+        }
+    }
+
     // Tests open long with an amount smaller than the minimum.
     #[tokio::test]
     async fn test_open_long_min_txn_amount() -> Result<()> {

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -80,6 +80,7 @@ impl State {
 
 #[cfg(test)]
 mod tests {
+    use ethers::types::U256;
     use eyre::Result;
     use fixed_point_macros::fixed;
     use rand::{thread_rng, Rng};
@@ -163,6 +164,18 @@ mod tests {
         let result = std::panic::catch_unwind(|| {
             state.calculate_open_long(state.config.minimum_transaction_amount - 10)
         });
+        assert!(result.is_err());
+        Ok(())
+    }
+
+    // Tests open short with an amount larger than the maximum.
+    #[tokio::test]
+    async fn test_open_long_max_amount() -> Result<()> {
+        let mut rng = thread_rng();
+        let state = rng.gen::<State>();
+        let max_long_amount = state.calculate_max_long(U256::MAX, 0), Some(7));
+        let result =
+            std::panic::catch_unwind(|| state.calculate_open_long(max_long_amount + fixed!(10e18)));
         assert!(result.is_err());
         Ok(())
     }

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -29,7 +29,6 @@ impl State {
             // TODO would be nice to return a `Result` here instead of a panic.
             panic!("MinimumTransactionAmount: Input amount too low");
         }
-        // TODO do we need to check minimum share price here?
 
         let long_amount =
             self.calculate_bonds_out_given_shares_in_down(base_amount / self.vault_share_price());

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -80,7 +80,6 @@ impl State {
 
 #[cfg(test)]
 mod tests {
-    use ethers::types::U256;
     use eyre::Result;
     use fixed_point_macros::fixed;
     use rand::{thread_rng, Rng};

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -173,7 +173,7 @@ mod tests {
     async fn test_open_long_max_amount() -> Result<()> {
         let mut rng = thread_rng();
         let state = rng.gen::<State>();
-        let max_long_amount = state.calculate_max_long(U256::MAX, 0), Some(7));
+        let max_long_amount = state.calculate_max_long(U256::MAX, 0, Some(7));
         let result =
             std::panic::catch_unwind(|| state.calculate_open_long(max_long_amount + fixed!(10e18)));
         assert!(result.is_err());

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -27,8 +27,9 @@ impl State {
         
         if base_amount < self.config.minimum_transaction_amount.into() {
             // TODO would be nice to return a `Result` here instead of a panic.
-            panic!("MinimumTransactionAmount: Base amount too low");
+            panic!("MinimumTransactionAmount: Input amount too low");
         }
+        // TODO do we need to check minimum share price here?
         
         let long_amount =
             self.calculate_bonds_out_given_shares_in_down(base_amount / self.vault_share_price());

--- a/crates/hyperdrive-math/src/short/close.rs
+++ b/crates/hyperdrive-math/src/short/close.rs
@@ -230,14 +230,14 @@ mod tests {
     async fn test_close_short_min_txn_amount() -> Result<()> {
         let mut rng = thread_rng();
         let state = rng.gen::<State>();
-        let result = std::panic::catch_unwind(|| 
+        let result = std::panic::catch_unwind(|| {
             state.calculate_close_short(
                 (state.config.minimum_transaction_amount - 10).into(),
                 state.get_spot_price(),
                 state.vault_share_price(),
                 0.into(),
             )
-        );
+        });
         assert!(result.is_err());
         Ok(())
     }

--- a/crates/hyperdrive-math/src/short/close.rs
+++ b/crates/hyperdrive-math/src/short/close.rs
@@ -233,8 +233,9 @@ mod tests {
         let result = std::panic::catch_unwind(|| {
             state.calculate_close_short(
                 (state.config.minimum_transaction_amount - 10).into(),
-                state.get_spot_price(),
+                state.calculate_spot_price(),
                 state.vault_share_price(),
+                0.into(),
                 0.into(),
             )
         });

--- a/crates/hyperdrive-math/src/short/close.rs
+++ b/crates/hyperdrive-math/src/short/close.rs
@@ -74,7 +74,7 @@ impl State {
     /// $$
     /// p_max = 1 - phi_c * (1 - p_0)
     /// $$
-    fn calculate_close_max_short_price(&self) -> FixedPoint {
+    fn calculate_close_short_max_spot_price(&self) -> FixedPoint {
         fixed!(1e18)
             - self
                 .curve_fee()
@@ -112,7 +112,7 @@ impl State {
             state.info.share_reserves += share_reserves_delta.into();
             state.calculate_spot_price()
         };
-        let max_spot_price = self.calculate_close_max_short_price();
+        let max_spot_price = self.calculate_close_short_max_spot_price();
         if ending_spot_price > max_spot_price {
             // TODO would be nice to return a `Result` here instead of a panic.
             panic!("InsufficientLiquidity: Negative Interest");

--- a/crates/hyperdrive-math/src/short/close.rs
+++ b/crates/hyperdrive-math/src/short/close.rs
@@ -94,6 +94,12 @@ impl State {
         let open_vault_share_price = open_vault_share_price.into();
         let close_vault_share_price = close_vault_share_price.into();
 
+        if bond_amount < self.config.minimum_transaction_amount.into() {
+            // TODO would be nice to return a `Result` here instead of a panic.
+            panic!("MinimumTransactionAmount: Input amount too low");
+        }
+
+
         // Calculate flat + curve and subtract the fees from the trade.
         let share_reserves_delta =
             self.calculate_close_short_flat_plus_curve(bond_amount, maturity_time, current_time)

--- a/crates/hyperdrive-math/src/short/close.rs
+++ b/crates/hyperdrive-math/src/short/close.rs
@@ -154,6 +154,7 @@ impl State {
         // Now calculate short proceeds
         // TODO we've already calculated a couple of internal variables needed by this function,
         // rework to avoid recalculating the curve and bond reserves
+        // https://github.com/delvtech/hyperdrive/issues/943
         let share_reserves_delta =
             self.calculate_close_short_flat_plus_curve(bond_amount, maturity_time, current_time);
         // Calculate flat + curve and subtract the fees from the trade.

--- a/crates/hyperdrive-math/src/short/close.rs
+++ b/crates/hyperdrive-math/src/short/close.rs
@@ -224,4 +224,21 @@ mod tests {
 
         Ok(())
     }
+
+    // Tests close short with an amount smaller than the minimum.
+    #[tokio::test]
+    async fn test_close_short_min_txn_amount() -> Result<()> {
+        let mut rng = thread_rng();
+        let state = rng.gen::<State>();
+        let result = std::panic::catch_unwind(|| 
+            state.calculate_close_short(
+                (state.config.minimum_transaction_amount - 10).into(),
+                state.get_spot_price(),
+                state.vault_share_price(),
+                0.into(),
+            )
+        );
+        assert!(result.is_err());
+        Ok(())
+    }
 }

--- a/crates/hyperdrive-math/src/short/close.rs
+++ b/crates/hyperdrive-math/src/short/close.rs
@@ -99,7 +99,6 @@ impl State {
             panic!("MinimumTransactionAmount: Input amount too low");
         }
 
-
         // Calculate flat + curve and subtract the fees from the trade.
         let share_reserves_delta =
             self.calculate_close_short_flat_plus_curve(bond_amount, maturity_time, current_time)

--- a/crates/hyperdrive-math/src/short/fees.rs
+++ b/crates/hyperdrive-math/src/short/fees.rs
@@ -40,6 +40,19 @@ impl State {
             * bond_amount.mul_div_down(normalized_time_remaining, self.vault_share_price())
     }
 
+    // Calculate the curve portion of the governance fee for close shorts
+    // NOTE: Round down to underestimate the governance curve fee
+    // TODO: avoid duplicate calculation of close short curve fee
+    pub fn close_short_governance_fee(
+        &self,
+        bond_amount: FixedPoint,
+        maturity_time: U256,
+        current_time: U256,
+    ) -> FixedPoint {
+        self.close_short_curve_fee(bond_amount, maturity_time, current_time)
+            .mul_down(self.governance_lp_fee())
+    }
+
     /// Calculates the flat fee paid by shorts for a given bond amount
     /// Returns the fee in shares
     pub fn close_short_flat_fee(

--- a/crates/hyperdrive-math/src/short/fees.rs
+++ b/crates/hyperdrive-math/src/short/fees.rs
@@ -43,6 +43,7 @@ impl State {
     // Calculate the curve portion of the governance fee for close shorts
     // NOTE: Round down to underestimate the governance curve fee
     // TODO: avoid duplicate calculation of close short curve fee
+    // https://github.com/delvtech/hyperdrive/issues/943
     pub fn close_short_governance_fee(
         &self,
         bond_amount: FixedPoint,

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -188,7 +188,7 @@ mod tests {
         let result = std::panic::catch_unwind(|| {
             state.calculate_open_short(
                 (state.config.minimum_transaction_amount - 10).into(),
-                state.get_spot_price(),
+                state.calculate_spot_price(),
                 state.vault_share_price(),
             )
         });

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -195,4 +195,21 @@ mod tests {
         assert!(result.is_err());
         Ok(())
     }
+
+    // Tests open short with an amount larger than the maximum.
+    #[tokio::test]
+    async fn test_open_short_max_amount() -> Result<()> {
+        let mut rng = thread_rng();
+        let state = rng.gen::<State>();
+        let max_short_amount = state.calculate_max_short(U256::MAX, fixed!(0), 0, None, Some(7));
+        let result = std::panic::catch_unwind(|| {
+            state.calculate_open_short(
+                max_short_amount + fixed!(10e18),
+                state.calculate_spot_price(),
+                state.vault_share_price(),
+            )
+        });
+        assert!(result.is_err());
+        Ok(())
+    }
 }

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -179,4 +179,20 @@ mod tests {
 
         Ok(())
     }
+
+    // Tests open short with an amount smaller than the minimum.
+    #[tokio::test]
+    async fn test_open_short_min_txn_amount() -> Result<()> {
+        let mut rng = thread_rng();
+        let state = rng.gen::<State>();
+        let result = std::panic::catch_unwind(|| 
+            state.calculate_open_short(
+                (state.config.minimum_transaction_amount - 10).into(),
+                state.get_spot_price(),
+                state.vault_share_price(),
+            )
+        );
+        assert!(result.is_err());
+        Ok(())
+    }
 }

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -33,7 +33,6 @@ impl State {
         spot_price: FixedPoint,
         mut open_vault_share_price: FixedPoint,
     ) -> Result<FixedPoint> {
-
         if short_amount < self.config.minimum_transaction_amount.into() {
             // TODO would be nice to return a `Result` here instead of a panic.
             panic!("MinimumTransactionAmount: Input amount too low");
@@ -47,7 +46,8 @@ impl State {
         }
 
         // TODO solidity uses mulUp here, should we do that here as well?
-        let share_reserves_delta_in_shares = self.vault_share_price() * self.short_principal(short_amount)?;
+        let share_reserves_delta_in_shares =
+            self.vault_share_price() * self.short_principal(short_amount)?;
         // If the base proceeds of selling the bonds is greater than the bond
         // amount, then the trade occurred in the negative interest domain. We
         // revert in these pathological cases.
@@ -61,7 +61,7 @@ impl State {
             short_amount.mul_div_down(self.vault_share_price(), open_vault_share_price)
                 + self.flat_fee() * short_amount
                 + self.curve_fee() * (fixed!(1e18) - spot_price) * short_amount
-                - share_reserves_delta_in_shares
+                - share_reserves_delta_in_shares,
         )
     }
 

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -33,6 +33,12 @@ impl State {
         spot_price: FixedPoint,
         mut open_vault_share_price: FixedPoint,
     ) -> Result<FixedPoint> {
+
+        if short_amount < self.config.minimum_transaction_amount.into() {
+            // TODO would be nice to return a `Result` here instead of a panic.
+            panic!("MinimumTransactionAmount: Input amount too low");
+        }
+
         // If the open share price hasn't been set, we use the current share
         // price, since this is what will be set as the checkpoint share price
         // in the next transaction.

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -45,13 +45,13 @@ impl State {
             open_vault_share_price = self.vault_share_price();
         }
 
-        // TODO solidity uses mulUp here, should we do that here as well?
-        let share_reserves_delta_in_shares =
-            self.vault_share_price() * self.short_principal(short_amount)?;
+        let share_reserves_delta_in_base = self
+            .vault_share_price()
+            .mul_up(self.short_principal(short_amount)?);
         // If the base proceeds of selling the bonds is greater than the bond
         // amount, then the trade occurred in the negative interest domain. We
         // revert in these pathological cases.
-        if share_reserves_delta_in_shares > short_amount {
+        if share_reserves_delta_in_base > short_amount {
             // TODO would be nice to return a `Result` here instead of a panic.
             panic!("InsufficientLiquidity: Negative Interest");
         }
@@ -61,7 +61,7 @@ impl State {
             short_amount.mul_div_down(self.vault_share_price(), open_vault_share_price)
                 + self.flat_fee() * short_amount
                 + self.curve_fee() * (fixed!(1e18) - spot_price) * short_amount
-                - share_reserves_delta_in_shares,
+                - share_reserves_delta_in_base,
         )
     }
 

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -195,4 +195,16 @@ mod tests {
         assert!(result.is_err());
         Ok(())
     }
+
+    // TODO ideally we would test calculate open short with an amount larger than the maximum size.
+    // However, `calculate_max_short` requires a `checkpoint_exposure`` argument, which requires
+    // implementing checkpointing in the rust sdk.
+    // https://github.com/delvtech/hyperdrive/issues/862
+
+    // TODO ideally we would add a solidity fuzz test that tests `calculate_open_short` against
+    // opening longs in solidity, where we attempt to trade outside of expected values (so that
+    // we can also test error parities as well). However, the current test chain only exposes
+    // the underlying hyperdrive math functions, which doesn't take into account fees and negative
+    // interest checks.
+    // https://github.com/delvtech/hyperdrive/issues/937
 }

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -104,7 +104,6 @@ impl State {
 
 #[cfg(test)]
 mod tests {
-    use ethers::types::{I256, U256};
     use fixed_point_macros::fixed;
     use rand::{thread_rng, Rng};
     use test_utils::{

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -104,7 +104,7 @@ impl State {
 
 #[cfg(test)]
 mod tests {
-    use ethers::types::U256;
+    use ethers::types::{I256, U256};
     use fixed_point_macros::fixed;
     use rand::{thread_rng, Rng};
     use test_utils::{
@@ -189,23 +189,6 @@ mod tests {
         let result = std::panic::catch_unwind(|| {
             state.calculate_open_short(
                 (state.config.minimum_transaction_amount - 10).into(),
-                state.calculate_spot_price(),
-                state.vault_share_price(),
-            )
-        });
-        assert!(result.is_err());
-        Ok(())
-    }
-
-    // Tests open short with an amount larger than the maximum.
-    #[tokio::test]
-    async fn test_error_open_short_max_amount() -> Result<()> {
-        let mut rng = thread_rng();
-        let state = rng.gen::<State>();
-        let max_short_amount = state.calculate_max_short(U256::MAX, fixed!(0), 0, None, Some(7));
-        let result = std::panic::catch_unwind(|| {
-            state.calculate_open_short(
-                max_short_amount + fixed!(10e18),
                 state.calculate_spot_price(),
                 state.vault_share_price(),
             )

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -185,13 +185,13 @@ mod tests {
     async fn test_open_short_min_txn_amount() -> Result<()> {
         let mut rng = thread_rng();
         let state = rng.gen::<State>();
-        let result = std::panic::catch_unwind(|| 
+        let result = std::panic::catch_unwind(|| {
             state.calculate_open_short(
                 (state.config.minimum_transaction_amount - 10).into(),
                 state.get_spot_price(),
                 state.vault_share_price(),
             )
-        );
+        });
         assert!(result.is_err());
         Ok(())
     }

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -104,6 +104,7 @@ impl State {
 
 #[cfg(test)]
 mod tests {
+    use ethers::types::U256;
     use fixed_point_macros::fixed;
     use rand::{thread_rng, Rng};
     use test_utils::{
@@ -182,7 +183,7 @@ mod tests {
 
     // Tests open short with an amount smaller than the minimum.
     #[tokio::test]
-    async fn test_open_short_min_txn_amount() -> Result<()> {
+    async fn test_error_open_short_min_txn_amount() -> Result<()> {
         let mut rng = thread_rng();
         let state = rng.gen::<State>();
         let result = std::panic::catch_unwind(|| {
@@ -198,7 +199,7 @@ mod tests {
 
     // Tests open short with an amount larger than the maximum.
     #[tokio::test]
-    async fn test_open_short_max_amount() -> Result<()> {
+    async fn test_error_open_short_max_amount() -> Result<()> {
         let mut rng = thread_rng();
         let state = rng.gen::<State>();
         let max_short_amount = state.calculate_max_short(U256::MAX, fixed!(0), 0, None, Some(7));


### PR DESCRIPTION
# Resolved Issues
https://github.com/delvtech/hyperdrive/issues/743 (partially)

# Description
Adds the following error checks in rust trades:
- Minimum transaction checks for all long and short trades.
- Adds negative interest checks for open and close shorts.

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed. If there are
multiple reviewers, copy the checklists into sections titled `## [Reviewer Name]`.
If the PR doesn't touch Solidity and/or Rust, the corresponding checklist can
be removed.

## @ryangoree 

### Rust

- [ ] **Testing**
    - [x] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [x] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
          
## @dpaiton  

### Rust

- [x] **Testing**
    - [x] Are there new or updated unit or integration tests?
    - [x] Do the tests cover the happy paths?
    - [x] Do the tests cover the unhappy paths?
    - [x] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [x] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
