### PR TITLE
add `calculate_spot_rate_after_long` and general cleanup

### DIFF
--- a/crates/fixed-point/src/lib.rs
+++ b/crates/fixed-point/src/lib.rs
@@ -480,8 +480,7 @@ impl UniformSampler for UniformFixedPoint {
 mod tests {
     use std::panic;
 
-    use eyre::Result;
-    use rand::{thread_rng, Rng};
+    use rand::thread_rng;
     use test_utils::{chain::TestChainWithMocks, constants::FAST_FUZZ_RUNS};
 
     use super::*;

--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -6,14 +6,12 @@ mod yield_space;
 
 use ethers::types::{Address, I256, U256};
 use fixed_point::FixedPoint;
-use fixed_point_macros::{fixed, uint256};
+use fixed_point_macros::fixed;
 use hyperdrive_wrappers::wrappers::ihyperdrive::{Fees, PoolConfig, PoolInfo};
-pub use long::*;
 use rand::{
     distributions::{Distribution, Standard},
     Rng,
 };
-pub use short::*;
 pub use utils::*;
 pub use yield_space::YieldSpace;
 

--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -124,7 +124,7 @@ impl State {
         let annualized_time =
             self.position_duration() / FixedPoint::from(U256::from(60 * 60 * 24 * 365));
         let spot_price = self.calculate_spot_price();
-        (fixed!(1e18) - spot_price) / (spot_price * annualized_time)
+        calculate_fixed_rate_from_price(spot_price, annualized_time)
     }
 
     /// Converts a timestamp to the checkpoint timestamp that it corresponds to.

--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -119,12 +119,12 @@ impl State {
         YieldSpace::calculate_spot_price(self)
     }
 
-    /// Calculates the pool's spot rate.
+    /// Calculate the spot rate assuming a the pool's spot price is constant over its annualized position duration.
     pub fn calculate_spot_rate(&self) -> FixedPoint {
-        let annualized_time =
-            self.position_duration() / FixedPoint::from(U256::from(60 * 60 * 24 * 365));
-        let spot_price = self.calculate_spot_price();
-        calculate_fixed_rate_from_price(spot_price, annualized_time)
+        calculate_rate_given_fixed_price(
+            self.calculate_spot_price(),
+            self.annualized_position_duration(),
+        )
     }
 
     /// Converts a timestamp to the checkpoint timestamp that it corresponds to.
@@ -151,6 +151,10 @@ impl State {
 
     fn position_duration(&self) -> FixedPoint {
         self.config.position_duration.into()
+    }
+
+    fn annualized_position_duration(&self) -> FixedPoint {
+        self.position_duration() / FixedPoint::from(U256::from(60 * 60 * 24 * 365))
     }
 
     fn checkpoint_duration(&self) -> FixedPoint {

--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -119,12 +119,9 @@ impl State {
         YieldSpace::calculate_spot_price(self)
     }
 
-    /// Calculate the spot rate assuming a the pool's spot price is constant over its annualized position duration.
+    /// Calculate the pool's current spot (aka "fixed") rate.
     pub fn calculate_spot_rate(&self) -> FixedPoint {
-        calculate_rate_given_fixed_price(
-            self.calculate_spot_price(),
-            self.annualized_position_duration(),
-        )
+        calculate_rate_given_fixed_price(self.calculate_spot_price(), self.position_duration())
     }
 
     /// Converts a timestamp to the checkpoint timestamp that it corresponds to.

--- a/crates/hyperdrive-math/src/long.rs
+++ b/crates/hyperdrive-math/src/long.rs
@@ -2,8 +2,3 @@ mod close;
 mod fees;
 mod max;
 mod open;
-
-pub use close::*;
-pub use fees::*;
-pub use max::*;
-pub use open::*;

--- a/crates/hyperdrive-math/src/long/close.rs
+++ b/crates/hyperdrive-math/src/long/close.rs
@@ -57,7 +57,6 @@ mod tests {
     use test_utils::{chain::TestChainWithMocks, constants::FAST_FUZZ_RUNS};
 
     use super::*;
-    use crate::State;
 
     #[tokio::test]
     async fn fuzz_calculate_close_long_flat_plus_curve() -> Result<()> {

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -624,7 +624,7 @@ mod tests {
             let spot_price_after_long = bob
                 .get_state()
                 .await?
-                .calculate_spot_price_after_long(max_long);
+                .calculate_spot_price_after_long(max_long, None);
             bob.open_long(max_long, None, None).await?;
 
             // One of three things should be true after opening the long:

--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -71,7 +71,7 @@ impl State {
     ) -> FixedPoint {
         calculate_rate_given_fixed_price(
             self.calculate_spot_price_after_long(base_amount, bond_amount),
-            self.annualized_position_duration(),
+            self.position_duration(),
         )
     }
 }

--- a/crates/hyperdrive-math/src/lp.rs
+++ b/crates/hyperdrive-math/src/lp.rs
@@ -14,7 +14,7 @@ impl State {
 
         // Calculate the idle base reserves.
         let mut idle_shares_in_base = fixed!(0);
-        if self.share_reserves() > long_exposure + self.minimum_share_reserves() {
+        if self.share_reserves() > (long_exposure + self.minimum_share_reserves()) {
             idle_shares_in_base =
                 (self.share_reserves() - long_exposure - self.minimum_share_reserves())
                     * self.vault_share_price();

--- a/crates/hyperdrive-math/src/lp.rs
+++ b/crates/hyperdrive-math/src/lp.rs
@@ -14,7 +14,7 @@ impl State {
 
         // Calculate the idle base reserves.
         let mut idle_shares_in_base = fixed!(0);
-        if (self.share_reserves() > long_exposure + self.minimum_share_reserves()) {
+        if self.share_reserves() > long_exposure + self.minimum_share_reserves() {
             idle_shares_in_base =
                 (self.share_reserves() - long_exposure - self.minimum_share_reserves())
                     * self.vault_share_price();

--- a/crates/hyperdrive-math/src/short.rs
+++ b/crates/hyperdrive-math/src/short.rs
@@ -2,8 +2,3 @@ mod close;
 mod fees;
 mod max;
 mod open;
-
-pub use close::*;
-pub use fees::*;
-pub use max::*;
-pub use open::*;

--- a/crates/hyperdrive-math/src/short/close.rs
+++ b/crates/hyperdrive-math/src/short/close.rs
@@ -105,7 +105,6 @@ mod tests {
     use test_utils::{chain::TestChainWithMocks, constants::FAST_FUZZ_RUNS};
 
     use super::*;
-    use crate::State;
 
     #[tokio::test]
     async fn fuzz_calculate_short_proceeds() -> Result<()> {

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -1,4 +1,3 @@
-use ethers::types::I256;
 use eyre::Result;
 use fixed_point::FixedPoint;
 use fixed_point_macros::fixed;
@@ -98,8 +97,7 @@ impl State {
 mod tests {
     use std::panic;
 
-    use ethers::types::U256;
-    use eyre::Result;
+    use ethers::types::{I256, U256};
     use hyperdrive_wrappers::wrappers::mock_hyperdrive_math::MaxTradeParams;
     use rand::{thread_rng, Rng};
     use test_utils::{chain::TestChainWithMocks, constants::FAST_FUZZ_RUNS};

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -67,16 +67,6 @@ impl State {
         state.calculate_spot_price()
     }
 
-    #[deprecated(since = "0.4.0", note = "please use `calculate_open_short` instead")]
-    pub fn calculate_short_deposit(
-        &self,
-        short_amount: FixedPoint,
-        spot_price: FixedPoint,
-        open_vault_share_price: FixedPoint,
-    ) -> Result<FixedPoint> {
-        self.calculate_open_short(short_amount, spot_price, open_vault_share_price)
-    }
-
     /// Calculates the amount of short principal that the LPs need to pay to back a
     /// short before fees are taken into consideration, $P(x)$.
     ///

--- a/crates/hyperdrive-math/src/utils.rs
+++ b/crates/hyperdrive-math/src/utils.rs
@@ -98,6 +98,24 @@ pub fn calculate_initial_bond_reserves(
         .mul_down(inner)
 }
 
+/// Calculate the spot (aka fixed) rate for a given price and normalized position duration.
+///
+/// We calculate the rate for a fixed length of time as:
+///
+/// $$
+/// r = (1 - p) / (p t)
+/// $$
+///
+/// where $p$ is the price and $t$ is the length of time that this price is
+/// assumed to be constant, in units of years. For example, if the price is
+/// constant for 6 months, then $t=0.5$.
+pub fn calculate_fixed_rate_from_price(
+    price: FixedPoint,
+    fixed_price_duration_in_years: FixedPoint,
+) -> FixedPoint {
+    (fixed!(1e18) - price) / (price * fixed_price_duration_in_years)
+}
+
 #[cfg(test)]
 mod tests {
     use std::panic;

--- a/crates/hyperdrive-math/src/utils.rs
+++ b/crates/hyperdrive-math/src/utils.rs
@@ -98,7 +98,7 @@ pub fn calculate_initial_bond_reserves(
         .mul_down(inner)
 }
 
-/// Calculate the spot (aka fixed) rate for a given price and normalized position duration.
+/// Calculate the rate assuming a given price is constant for some annualized duration.
 ///
 /// We calculate the rate for a fixed length of time as:
 ///
@@ -109,7 +109,7 @@ pub fn calculate_initial_bond_reserves(
 /// where $p$ is the price and $t$ is the length of time that this price is
 /// assumed to be constant, in units of years. For example, if the price is
 /// constant for 6 months, then $t=0.5$.
-pub fn calculate_fixed_rate_from_price(
+pub fn calculate_rate_given_fixed_price(
     price: FixedPoint,
     fixed_price_duration_in_years: FixedPoint,
 ) -> FixedPoint {

--- a/crates/hyperdrive-math/src/utils.rs
+++ b/crates/hyperdrive-math/src/utils.rs
@@ -109,10 +109,13 @@ pub fn calculate_initial_bond_reserves(
 /// where $p$ is the price and $t$ is the length of time that this price is
 /// assumed to be constant, in units of years. For example, if the price is
 /// constant for 6 months, then $t=0.5$.
+/// In our case, $t = \text{position_duration} / (60*60*24*365)$.
 pub fn calculate_rate_given_fixed_price(
     price: FixedPoint,
-    fixed_price_duration_in_years: FixedPoint,
+    position_duration: FixedPoint,
 ) -> FixedPoint {
+    let fixed_price_duration_in_years =
+        position_duration / FixedPoint::from(U256::from(60 * 60 * 24 * 365));
     (fixed!(1e18) - price) / (price * fixed_price_duration_in_years)
 }
 

--- a/crates/hyperdrive-math/src/yield_space.rs
+++ b/crates/hyperdrive-math/src/yield_space.rs
@@ -344,7 +344,6 @@ pub trait YieldSpace {
 mod tests {
     use std::panic;
 
-    use eyre::Result;
     use rand::{thread_rng, Rng};
     use test_utils::{chain::TestChainWithMocks, constants::FAST_FUZZ_RUNS};
 

--- a/crates/hyperdrive-math/tests/integration_tests.rs
+++ b/crates/hyperdrive-math/tests/integration_tests.rs
@@ -216,7 +216,7 @@ pub async fn test_integration_calculate_max_long() -> Result<()> {
         let spot_price_after_long = bob
             .get_state()
             .await?
-            .calculate_spot_price_after_long(max_long);
+            .calculate_spot_price_after_long(max_long, None);
         bob.open_long(max_long, None, None).await?;
         let is_max_price = max_spot_price - spot_price_after_long < fixed!(1e15);
         let is_solvency_consumed = {

--- a/crates/test-utils/src/chain/dev_chain.rs
+++ b/crates/test-utils/src/chain/dev_chain.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, time::Duration};
+use std::time::Duration;
 
 use ethers::{
     providers::{Http, Provider},

--- a/crates/test-utils/src/chain/test_chain.rs
+++ b/crates/test-utils/src/chain/test_chain.rs
@@ -1,4 +1,4 @@
-use std::{convert::TryFrom, sync::Arc, time::Duration};
+use std::{sync::Arc, time::Duration};
 
 use ethers::{
     core::utils::{keccak256, Anvil},
@@ -1326,9 +1326,6 @@ impl TestChainWithMocks {
 
 #[cfg(test)]
 mod tests {
-    use hyperdrive_math::calculate_time_stretch;
-    use hyperdrive_wrappers::wrappers::ihyperdrive::{Fees, IHyperdrive};
-
     use super::*;
 
     #[tokio::test]


### PR DESCRIPTION
# Resolved Issues
Addresses one component required for https://github.com/delvtech/hyperdrive/issues/775

# Description
- Adds a helper function to calculate the spot rate after a long is opened
- Cleans up rust compiler warnings about unused imports
- Adds an optional `bond_amount` argument to `calculate_spot_price_after_long` to prevent duplicate calls to `open_long` and to better match the signature for `calculate_spot_price_after_short`.
- Removes deprecated `calculate_short_deposit` (used to  be `get_short_deposit`) that has not been recommended since `0.4.0`

I didn't fuzz test this against solidity because it uses the rust open long flow, which is tested against solidity. This follows the same pattern as `calculate_spot_price_after_long`.

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed. If there are
multiple reviewers, copy the checklists into sections titled `## [Reviewer Name]`.
If the PR doesn't touch Solidity and/or Rust, the corresponding checklist can
be removed.

## [[Reviewer Name]]


### Rust

- [ ] **Testing**
    - [x] Are there new or updated unit or integration tests?
    - [x] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [x] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [x] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
