### PR TITLE
Add Instance Test owners to CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -8,3 +8,10 @@ Cargo.toml @jalextowle @jrhea @mcclurejt @dpaiton @slundqui @ryangoree
 rustfmt.toml @jalextowle @jrhea @mcclurejt @dpaiton @slundqui @ryangoree
 Makefile @jalextowle @jrhea @mcclurejt @dpaiton @slundqui @ryangoree
 README.md @jalextowle @jrhea @mcclurejt @dpaiton @slundqui @ryangoree
+
+# Instance Owners
+contracts/src/deployers/ @mcclurejt @cashd @sentilesdal
+contracts/src/instances/ @mcclurejt @cashd @sentilesdal
+contracts/src/interfaces/ @mcclurejt @cashd @sentilesdal
+contracts/test/ @mcclurejt @cashd @sentilesdal
+test/ @mcclurejt @cashd @sentilesdal

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -10,8 +10,8 @@ Makefile @jalextowle @jrhea @mcclurejt @dpaiton @slundqui @ryangoree
 README.md @jalextowle @jrhea @mcclurejt @dpaiton @slundqui @ryangoree
 
 # Instance Owners
-contracts/src/deployers/ @mcclurejt @cashd @sentilesdal
-contracts/src/instances/ @mcclurejt @cashd @sentilesdal
-contracts/src/interfaces/ @mcclurejt @cashd @sentilesdal
-contracts/test/ @mcclurejt @cashd @sentilesdal
-test/ @mcclurejt @cashd @sentilesdal
+contracts/src/deployers/ @jalextowle @jrhea @mcclurejt @cashd @sentilesdal
+contracts/src/instances/ @jalextowle @jrhea @mcclurejt @cashd @sentilesdal
+contracts/src/interfaces/ @jalextowle @jrhea @mcclurejt @cashd @sentilesdal
+contracts/test/ @jalextowle @jrhea @mcclurejt @cashd @sentilesdal
+test/ @jalextowle @jrhea @mcclurejt @cashd @sentilesdal


### PR DESCRIPTION
# Description
Add Cash and Matt as code owners for directories that are often modified when creating new instances and testing.


