### PR TITLE
Add `calculate_add_liquidity` to rust sdk.

### DIFF
--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -227,6 +227,18 @@ impl State {
     fn share_adjustment(&self) -> I256 {
         self.info.share_adjustment
     }
+
+    fn lp_total_supply(&self) -> FixedPoint {
+        self.info.lp_total_supply.into()
+    }
+
+    fn withdrawal_shares_proceeds(&self) -> FixedPoint {
+        self.info.withdrawal_shares_proceeds.into()
+    }
+
+    fn withdrawal_shares_ready_to_withdraw(&self) -> FixedPoint {
+        self.info.withdrawal_shares_ready_to_withdraw.into()
+    }
 }
 
 impl YieldSpace for State {

--- a/crates/hyperdrive-math/src/lp.rs
+++ b/crates/hyperdrive-math/src/lp.rs
@@ -1,12 +1,161 @@
-use std::cmp::{max, Ordering};
+use eyre::{eyre, Result};
+use std::cmp::Ordering;
 
 use ethers::types::{I256, U256};
 use fixed_point::FixedPoint;
 use fixed_point_macros::{fixed, int256};
 
-use crate::{get_effective_share_reserves, State, YieldSpace};
+use crate::{calculate_effective_share_reserves, State, YieldSpace};
 
 impl State {
+    // Calculates the lp_shares for a given contribution when adding liquidity.
+    pub fn calculate_add_liquidity(
+        &self,
+        current_block_timestamp: U256,
+        contribution: FixedPoint,
+        min_lp_share_price: FixedPoint,
+        min_apr: FixedPoint,
+        max_apr: FixedPoint,
+        as_base: bool,
+    ) -> Result<FixedPoint> {
+        // Ensure that the contribution is greater than or equal to the minimum
+        // transaction amount.
+        if contribution < self.minimum_transaction_amount() {
+            return Err(eyre!(
+                "MinimumTransactionAmount: Contribution is smaller than the minimum transaction."
+            ));
+        }
+
+        // Enforce the slippage guard.
+        let apr = self.calculate_spot_rate();
+        if apr < min_apr || apr > max_apr {
+            return Err(eyre!("InvalidApr: Apr is outside the slippage guard."));
+        }
+
+        // Get lp_total_supply for the lp_shares calculation.
+        let lp_total_supply = self.lp_total_supply();
+
+        // Get the starting_present_value.
+        let starting_present_value = self.calculate_present_value(current_block_timestamp);
+
+        // Get the ending_present_value.
+        let share_contribution = {
+            if as_base {
+                // Attempt a crude conversion from base to shares.
+                I256::try_from(contribution / self.vault_share_price()).unwrap()
+            } else {
+                I256::try_from(contribution).unwrap()
+            }
+        };
+        let new_state = self.get_state_after_liquidity_update(share_contribution);
+        let ending_present_value = new_state.calculate_present_value(current_block_timestamp);
+
+        // Ensure the present value didn't decrease after adding liquidity.
+        if ending_present_value < starting_present_value {
+            return Err(eyre!("DecreasedPresentValueWhenAddingLiquidity: Present value decreased after adding liquidity."));
+        }
+
+        // Calculate the lp_shares.
+        let lp_shares = (ending_present_value - starting_present_value)
+            .mul_div_down(lp_total_supply, starting_present_value);
+
+        // Ensure that enough lp_shares are minted so that they can be redeemed.
+        if lp_shares < self.minimum_transaction_amount() {
+            return Err(eyre!(
+                "MinimumTransactionAmount: Not enough lp shares minted."
+            ));
+        }
+
+        // Enforce the minimum LP share price slippage guard.
+        if contribution.div_down(lp_shares) < min_lp_share_price {
+            return Err(eyre!("OutputLimit: not enough lp shares minted."));
+        }
+
+        Ok(lp_shares)
+    }
+
+    // Gets the resulting state when updating liquidity.
+    pub fn get_state_after_liquidity_update(&self, share_reserves_delta: I256) -> State {
+        let share_reserves = self.share_reserves();
+        let share_adjustment = self.share_adjustment();
+        let bond_reserves = self.bond_reserves();
+        let minimum_share_reserves = self.minimum_share_reserves();
+
+        // Calculate new reserve and adjustment levels.
+        let (updated_share_reserves, updated_share_adjustment, updated_bond_reserves) = self
+            .calculate_update_liquidity(
+                share_reserves,
+                share_adjustment,
+                bond_reserves,
+                minimum_share_reserves,
+                share_reserves_delta,
+            )
+            .unwrap();
+
+        // Update and return the new state.
+        let mut new_info = self.info.clone();
+        new_info.share_reserves = U256::from(updated_share_reserves);
+        new_info.share_adjustment = updated_share_adjustment;
+        new_info.bond_reserves = U256::from(updated_bond_reserves);
+        State {
+            config: self.config.clone(),
+            info: new_info,
+        }
+    }
+
+    // Calculates the resulting share_reserves, bond_reserves and
+    // share_adjustment when updating liquidity with a share_reserves_delta.
+    fn calculate_update_liquidity(
+        &self,
+        share_reserves: FixedPoint,
+        share_adjustment: I256,
+        bond_reserves: FixedPoint,
+        minimum_share_reserves: FixedPoint,
+        share_reserves_delta: I256,
+    ) -> Result<(FixedPoint, I256, FixedPoint), &'static str> {
+        if share_reserves_delta == I256::zero() {
+            return Ok((share_reserves, share_adjustment, bond_reserves));
+        }
+
+        // Get the updated share reserves.
+        let new_share_reserves = if share_reserves_delta > I256::zero() {
+            I256::try_from(share_reserves).unwrap() + share_reserves_delta
+        } else {
+            I256::try_from(share_reserves).unwrap() - share_reserves_delta
+        };
+
+        // Ensure the minimum share reserve level.
+        if new_share_reserves < I256::try_from(minimum_share_reserves).unwrap() {
+            return Err("Update would result in share reserves below minimum.");
+        }
+
+        // Convert to Fixedpoint to allow the math below.
+        let new_share_reserves = FixedPoint::from(new_share_reserves);
+
+        // Get the updated share adjustment.
+        let new_share_adjustment = if share_adjustment >= I256::zero() {
+            let share_adjustment_fp = FixedPoint::from(share_adjustment);
+            I256::try_from(new_share_reserves.mul_div_down(share_adjustment_fp, share_reserves))
+                .unwrap()
+        } else {
+            let share_adjustment_fp = FixedPoint::from(-share_adjustment);
+            -I256::try_from(new_share_reserves.mul_div_up(share_adjustment_fp, share_reserves))
+                .unwrap()
+        };
+
+        // Get the updated bond reserves.
+        let old_effective_share_reserves = calculate_effective_share_reserves(
+            self.effective_share_reserves(),
+            self.share_adjustment(),
+        );
+        let new_effective_share_reserves =
+            calculate_effective_share_reserves(new_share_reserves, new_share_adjustment);
+        let new_bond_reserves =
+            bond_reserves.mul_div_down(new_effective_share_reserves, old_effective_share_reserves);
+
+        Ok((new_share_reserves, new_share_adjustment, new_bond_reserves))
+    }
+
     /// Calculates the number of base that are not reserved by open positions.
     pub fn calculate_idle_share_reserves_in_base(&self) -> FixedPoint {
         // NOTE: Round up to underestimate the pool's idle.
@@ -185,134 +334,6 @@ impl State {
             ))
             .unwrap()
     }
-
-    pub fn calculate_add_liquidity(
-        &self,
-        current_block_timestamp: U256,
-        contribution: FixedPoint,
-        min_apr: Option<FixedPoint>,
-        max_apr: Option<FixedPoint>,
-    ) -> Result<FixedPoint, &str> {
-        // Ensure that the contribution is greater than or equal to the minimum
-        // transaction amount.
-        if contribution < self.minimum_transaction_amount() {
-            return Err("MinimumTransactionAmount");
-        }
-
-        // Enforce the slippage guard.
-        if min_apr.is_some() && max_apr.is_some() {
-            let apr = self.get_spot_rate();
-            let invalid_apr = apr < min_apr.unwrap() || apr > max_apr.unwrap();
-            if invalid_apr {
-                return Err("InvalidApr");
-            }
-        }
-
-        // Get withdraw_shares_outstanding and lp_total_supply for the lp_shares calculation.
-        let withdraw_shares_outstanding =
-            self.withdrawal_shares_proceeds() - self.withdrawal_shares_ready_to_withdraw();
-        let lp_total_supply = self.lp_total_supply() - withdraw_shares_outstanding;
-
-        // Get the starting_present_value.
-        let starting_present_value = self.calculate_present_value(current_block_timestamp);
-
-        // Get the ending_present_value.
-        let share_contribution = I256::try_from(contribution * self.vault_share_price()).unwrap();
-        let new_state = self.update_liquidity(share_contribution);
-        let ending_present_value = new_state.calculate_present_value(current_block_timestamp);
-
-        // Ensure the present value didn't decreased after adding liquidity.
-        if ending_present_value < starting_present_value {
-            return Err("DecreasedPresentValueWhenAddingLiquidity");
-        }
-
-        // Calculate the lp_shares.
-        let lp_shares = (ending_present_value - starting_present_value)
-            .mul_div_down(lp_total_supply, starting_present_value);
-
-        // Ensure that enough lp_shares are minted so that they can be redeemed.
-        if lp_shares < self.minimum_transaction_amount() {
-            return Err("MinimumTransactionAmount");
-        }
-
-        // TODO: add the solidity _distributeExcessIdleSafe check here.
-
-        return Ok(lp_shares);
-    }
-
-    fn update_liquidity(&self, share_reserves_delta: I256) -> State {
-        let share_reserves = self.share_reserves();
-        let share_adjustment = self.share_adjustment();
-        let bond_reserves = self.bond_reserves();
-        let minimum_share_reserves = self.minimum_share_reserves();
-
-        // Calculate new reserve and adjustment levels.
-        let (updated_share_reserves, updated_share_adjustment, updated_bond_reserves) = self
-            .calculate_update_liquidity(
-                share_reserves,
-                share_adjustment,
-                bond_reserves,
-                minimum_share_reserves,
-                share_reserves_delta,
-            )
-            .unwrap();
-
-        // Update and return the new state.
-        let mut new_info = self.info.clone();
-        new_info.share_reserves = U256::from(updated_share_reserves);
-        new_info.share_adjustment = updated_share_adjustment;
-        new_info.bond_reserves = U256::from(updated_bond_reserves);
-        State {
-            config: self.config.clone(),
-            info: new_info,
-        }
-    }
-
-    fn calculate_update_liquidity(
-        &self,
-        share_reserves: FixedPoint,
-        share_adjustment: I256,
-        bond_reserves: FixedPoint,
-        minimum_share_reserves: FixedPoint,
-        share_reserves_delta: I256,
-    ) -> Result<(FixedPoint, I256, FixedPoint), &'static str> {
-        if share_reserves_delta == I256::zero() {
-            return Ok((share_reserves, share_adjustment, bond_reserves));
-        }
-
-        // Get the updated share reserves.
-        let new_share_reserves = if share_reserves_delta > I256::zero() {
-            share_reserves + FixedPoint::from(share_reserves_delta)
-        } else {
-            share_reserves - FixedPoint::from(share_reserves_delta)
-        };
-
-        // Ensure the minimum share reserve level.
-        if new_share_reserves < minimum_share_reserves {
-            return Err("Update would result in share reserves below minimum.");
-        }
-
-        // Get the updated share adjustment.
-        let new_share_adjustment = if share_adjustment >= I256::zero() {
-            let share_adjustment_fp = FixedPoint::from(share_adjustment);
-            I256::try_from(new_share_reserves.mul_div_down(share_adjustment_fp, share_reserves))
-                .unwrap()
-        } else {
-            let share_adjustment_fp = FixedPoint::from(-share_adjustment);
-            -I256::try_from(new_share_reserves.mul_div_up(share_adjustment_fp, share_reserves))
-                .unwrap()
-        };
-
-        // Get the updated bond reserves.
-        let old_effective_share_reserves =
-            get_effective_share_reserves(self.effective_share_reserves(), self.share_adjustment());
-        let new_effective_share_reserves =
-            get_effective_share_reserves(new_share_reserves, new_share_adjustment);
-        let new_bond_reserves =
-            bond_reserves.mul_div_down(new_effective_share_reserves, old_effective_share_reserves);
-
-        Ok((new_share_reserves, new_share_adjustment, new_bond_reserves))
-    }
 }
 
 #[cfg(test)]
@@ -322,9 +343,90 @@ mod tests {
     use eyre::Result;
     use hyperdrive_wrappers::wrappers::mock_lp_math::PresentValueParams;
     use rand::{thread_rng, Rng};
-    use test_utils::{chain::TestChainWithMocks, constants::FAST_FUZZ_RUNS};
+    use test_utils::{
+        agent::Agent,
+        chain::{Chain, TestChain, TestChainWithMocks},
+        constants::FAST_FUZZ_RUNS,
+    };
 
     use super::*;
+
+    #[tokio::test]
+    async fn fuzz_test_calculate_add_liquidity() -> Result<()> {
+        // Spawn a test chain and create two agents -- Alice and Bob.
+        let mut rng = thread_rng();
+        let chain = TestChain::new(2).await?;
+        let (alice, bob) = (chain.accounts()[0].clone(), chain.accounts()[1].clone());
+        let mut alice =
+            Agent::new(chain.client(alice).await?, chain.addresses().clone(), None).await?;
+        let mut bob = Agent::new(chain.client(bob).await?, chain.addresses(), None).await?;
+        let config = bob.get_config().clone();
+
+        for _ in 0..*FAST_FUZZ_RUNS {
+            // Snapshot the chain.
+            let id = chain.snapshot().await?;
+
+            // Fund Alice and Bob.
+            let fixed_rate = rng.gen_range(fixed!(0.01e18)..=fixed!(0.1e18));
+            let contribution = rng.gen_range(fixed!(10_000e18)..=fixed!(500_000_000e18));
+            let budget = rng.gen_range(fixed!(10e18)..=fixed!(500_000_000e18));
+            alice.fund(contribution).await?;
+            bob.fund(budget).await?;
+
+            // Alice initializes the pool.
+            alice.initialize(fixed_rate, contribution, None).await?;
+
+            // Some of the checkpoint passes and variable interest accrues.
+            alice
+                .checkpoint(alice.latest_checkpoint().await?, None)
+                .await?;
+            let rate = rng.gen_range(fixed!(0)..=fixed!(0.5e18));
+            alice
+                .advance_time(
+                    rate,
+                    FixedPoint::from(config.checkpoint_duration) * fixed!(0.5e18),
+                )
+                .await?;
+
+            // Get the State from solidity before adding liquidity.
+            let hd_state = bob.get_state().await?;
+            let state = State {
+                config: hd_state.config.clone(),
+                info: hd_state.info.clone(),
+            };
+
+            // Bob adds liquidity
+            bob.add_liquidity(budget, None).await?;
+            let lp_shares_mock = bob.lp_shares();
+
+            // Calculate lp_shares from the rust function.
+            let lp_shares = state
+                .calculate_add_liquidity(
+                    bob.now().await?,
+                    budget,
+                    fixed!(0),
+                    fixed!(0),
+                    FixedPoint::from(U256::MAX),
+                    true,
+                )
+                .unwrap();
+
+            // Rust can't account for slippage.
+            assert!(lp_shares >= lp_shares_mock, "Should over estimate.");
+            // Answer should still be mostly the same.
+            assert!(
+                fixed!(1e18) - lp_shares_mock / lp_shares < fixed!(1e11),
+                "Difference should be less than 0.0000001."
+            );
+
+            // Revert to the snapshot and reset the agent's wallets.
+            chain.revert(id).await?;
+            alice.reset(Default::default());
+            bob.reset(Default::default());
+        }
+
+        Ok(())
+    }
 
     #[tokio::test]
     async fn fuzz_calculate_present_value() -> Result<()> {

--- a/crates/hyperdrive-math/src/lp.rs
+++ b/crates/hyperdrive-math/src/lp.rs
@@ -1,10 +1,10 @@
-use std::cmp::Ordering;
+use std::cmp::{max, Ordering};
 
 use ethers::types::{I256, U256};
 use fixed_point::FixedPoint;
 use fixed_point_macros::{fixed, int256};
 
-use crate::{State, YieldSpace};
+use crate::{get_effective_share_reserves, State, YieldSpace};
 
 impl State {
     /// Calculates the number of base that are not reserved by open positions.
@@ -184,6 +184,134 @@ impl State {
                 self.vault_share_price(),
             ))
             .unwrap()
+    }
+
+    pub fn calculate_add_liquidity(
+        &self,
+        current_block_timestamp: U256,
+        contribution: FixedPoint,
+        min_apr: Option<FixedPoint>,
+        max_apr: Option<FixedPoint>,
+    ) -> Result<FixedPoint, &str> {
+        // Ensure that the contribution is greater than or equal to the minimum
+        // transaction amount.
+        if contribution < self.minimum_transaction_amount() {
+            return Err("MinimumTransactionAmount");
+        }
+
+        // Enforce the slippage guard.
+        if min_apr.is_some() && max_apr.is_some() {
+            let apr = self.get_spot_rate();
+            let invalid_apr = apr < min_apr.unwrap() || apr > max_apr.unwrap();
+            if invalid_apr {
+                return Err("InvalidApr");
+            }
+        }
+
+        // Get withdraw_shares_outstanding and lp_total_supply for the lp_shares calculation.
+        let withdraw_shares_outstanding =
+            self.withdrawal_shares_proceeds() - self.withdrawal_shares_ready_to_withdraw();
+        let lp_total_supply = self.lp_total_supply() - withdraw_shares_outstanding;
+
+        // Get the starting_present_value.
+        let starting_present_value = self.calculate_present_value(current_block_timestamp);
+
+        // Get the ending_present_value.
+        let share_contribution = I256::try_from(contribution * self.vault_share_price()).unwrap();
+        let new_state = self.update_liquidity(share_contribution);
+        let ending_present_value = new_state.calculate_present_value(current_block_timestamp);
+
+        // Ensure the present value didn't decreased after adding liquidity.
+        if ending_present_value < starting_present_value {
+            return Err("DecreasedPresentValueWhenAddingLiquidity");
+        }
+
+        // Calculate the lp_shares.
+        let lp_shares = (ending_present_value - starting_present_value)
+            .mul_div_down(lp_total_supply, starting_present_value);
+
+        // Ensure that enough lp_shares are minted so that they can be redeemed.
+        if lp_shares < self.minimum_transaction_amount() {
+            return Err("MinimumTransactionAmount");
+        }
+
+        // TODO: add the solidity _distributeExcessIdleSafe check here.
+
+        return Ok(lp_shares);
+    }
+
+    fn update_liquidity(&self, share_reserves_delta: I256) -> State {
+        let share_reserves = self.share_reserves();
+        let share_adjustment = self.share_adjustment();
+        let bond_reserves = self.bond_reserves();
+        let minimum_share_reserves = self.minimum_share_reserves();
+
+        // Calculate new reserve and adjustment levels.
+        let (updated_share_reserves, updated_share_adjustment, updated_bond_reserves) = self
+            .calculate_update_liquidity(
+                share_reserves,
+                share_adjustment,
+                bond_reserves,
+                minimum_share_reserves,
+                share_reserves_delta,
+            )
+            .unwrap();
+
+        // Update and return the new state.
+        let mut new_info = self.info.clone();
+        new_info.share_reserves = U256::from(updated_share_reserves);
+        new_info.share_adjustment = updated_share_adjustment;
+        new_info.bond_reserves = U256::from(updated_bond_reserves);
+        State {
+            config: self.config.clone(),
+            info: new_info,
+        }
+    }
+
+    fn calculate_update_liquidity(
+        &self,
+        share_reserves: FixedPoint,
+        share_adjustment: I256,
+        bond_reserves: FixedPoint,
+        minimum_share_reserves: FixedPoint,
+        share_reserves_delta: I256,
+    ) -> Result<(FixedPoint, I256, FixedPoint), &'static str> {
+        if share_reserves_delta == I256::zero() {
+            return Ok((share_reserves, share_adjustment, bond_reserves));
+        }
+
+        // Get the updated share reserves.
+        let new_share_reserves = if share_reserves_delta > I256::zero() {
+            share_reserves + FixedPoint::from(share_reserves_delta)
+        } else {
+            share_reserves - FixedPoint::from(share_reserves_delta)
+        };
+
+        // Ensure the minimum share reserve level.
+        if new_share_reserves < minimum_share_reserves {
+            return Err("Update would result in share reserves below minimum.");
+        }
+
+        // Get the updated share adjustment.
+        let new_share_adjustment = if share_adjustment >= I256::zero() {
+            let share_adjustment_fp = FixedPoint::from(share_adjustment);
+            I256::try_from(new_share_reserves.mul_div_down(share_adjustment_fp, share_reserves))
+                .unwrap()
+        } else {
+            let share_adjustment_fp = FixedPoint::from(-share_adjustment);
+            -I256::try_from(new_share_reserves.mul_div_up(share_adjustment_fp, share_reserves))
+                .unwrap()
+        };
+
+        // Get the updated bond reserves.
+        let old_effective_share_reserves =
+            get_effective_share_reserves(self.effective_share_reserves(), self.share_adjustment());
+        let new_effective_share_reserves =
+            get_effective_share_reserves(new_share_reserves, new_share_adjustment);
+        let new_bond_reserves =
+            bond_reserves.mul_div_down(new_effective_share_reserves, old_effective_share_reserves);
+
+        Ok((new_share_reserves, new_share_adjustment, new_bond_reserves))
     }
 }
 

--- a/crates/hyperdrive-math/src/yield_space.rs
+++ b/crates/hyperdrive-math/src/yield_space.rs
@@ -280,7 +280,7 @@ pub trait YieldSpace {
         // fall below the minimum share reserves. Otherwise, the minimum share
         // reserves is just zMin.
         if self.zeta() < I256::zero() {
-            z_min = z_min + FixedPoint::from(-self.zeta());
+            z_min += FixedPoint::from(-self.zeta());
         }
 
         // We solve for the maximum sell using the constraint that the pool's


### PR DESCRIPTION
# Resolved Issues
https://github.com/orgs/delvtech/projects/13?pane=issue&itemId=58015840

# Description
Adds the rust function `calculate_add_liquidity`

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed. If there are
multiple reviewers, copy the checklists into sections titled `## [Reviewer Name]`.
If the PR doesn't touch Solidity and/or Rust, the corresponding checklist can
be removed.

## @dpaiton 


### Rust

- [ ] **Testing**
    - [x] Are there new or updated unit or integration tests?
    - [x] Do the tests cover the happy paths?
    - [x] Do the tests cover the unhappy paths?
    - [x] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [x] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
