### PR TITLE
Update that should hopefully fix merge groups

### DIFF
--- a/.github/workflows/check_diff.yaml
+++ b/.github/workflows/check_diff.yaml
@@ -51,7 +51,7 @@ jobs:
         if: github.event_name == 'merge_group'
         id: check-merge-group
         run: |
-          FILES_CHANGED=$(git diff --name-only ${{ github.event.merge_group.base_ref }} HEAD)
+          FILES_CHANGED=$(git diff --name-only ${{ github.event.merge_group.head_ref }} HEAD)
           if echo "$FILES_CHANGED" | grep -m 1 "${{ inputs.pattern }}"; then
             echo "changed=true" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
# Description

The previous `check-diff` workflow was failing. It seems like it was most likely failing because of the use of `base_ref` instead of `head_ref`. We'll try this again and see how it goes.