### PR TITLE
Fixing `calc_max_short` for accuracy

### DIFF
--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -581,6 +581,62 @@ mod tests {
 
     #[traced_test]
     #[tokio::test]
+    async fn test_max_long_derivative() -> Result<()> {
+        let mut rng = thread_rng();
+        // We use a relatively large epsilon here due to the underlying fixed point pow
+        // function not being monotonically increasing.
+        let empirical_derivative_epsilon = fixed!(1e12);
+        // TODO pretty big comparison epsilon here
+        let test_comparison_epsilon = fixed!(10e18);
+
+        for _ in 0..*FAST_FUZZ_RUNS {
+            let state = rng.gen::<State>();
+            // Bind the max amount by the absolute max amount
+            let amount = rng.gen_range(fixed!(10e18)..=fixed!(10_000_000e18));
+
+            let p1_result = std::panic::catch_unwind(|| {
+                state.calculate_open_long(amount - empirical_derivative_epsilon)
+            });
+            let p1;
+            let p2;
+            match p1_result {
+                Ok(p) => {
+                    p1 = p;
+                }
+                Err(_) => continue,
+            }
+
+            let p2_result = std::panic::catch_unwind(|| {
+                state.calculate_open_long(amount + empirical_derivative_epsilon)
+            });
+            match p2_result {
+                Ok(p) => {
+                    p2 = p;
+                }
+                Err(_) => continue,
+            }
+            // Sanity check
+            assert!(p2 > p1);
+
+            let empirical_derivative = (p2 - p1) / (fixed!(2e18) * empirical_derivative_epsilon);
+            let open_long_derivative = state.long_amount_derivative(amount);
+            open_long_derivative.map(|derivative| {
+                let abs_diff;
+                if derivative >= empirical_derivative {
+                    abs_diff = derivative - empirical_derivative;
+                } else {
+                    abs_diff = empirical_derivative - derivative;
+                }
+                println!("abs_diff: {}", abs_diff);
+                assert!(abs_diff < test_comparison_epsilon);
+            });
+        }
+
+        Ok(())
+    }
+
+    #[traced_test]
+    #[tokio::test]
     async fn test_calculate_max_long() -> Result<()> {
         // Spawn a test chain and create two agents -- Alice and Bob. Alice
         // is funded with a large amount of capital so that she can initialize

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -579,6 +579,9 @@ mod tests {
         Ok(())
     }
 
+    /// This test empirically tests the derivative of `long_amount_derivative`
+    /// by calling `calculate_open_long` at two points and comparing the empirical
+    /// result with the output of `long_amount_derivative`.
     #[traced_test]
     #[tokio::test]
     async fn test_max_long_derivative() -> Result<()> {

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -602,9 +602,10 @@ mod tests {
             let p1;
             let p2;
             match p1_result {
-                Ok(p) => {
-                    p1 = p;
-                }
+                Ok(p) => match p {
+                    Ok(p) => p1 = p,
+                    Err(_) => continue,
+                },
                 // If the amount results in the pool being insolvent, skip this iteration
                 Err(_) => continue,
             }
@@ -613,9 +614,10 @@ mod tests {
                 state.calculate_open_long(amount + empirical_derivative_epsilon)
             });
             match p2_result {
-                Ok(p) => {
-                    p2 = p;
-                }
+                Ok(p) => match p {
+                    Ok(p) => p2 = p,
+                    Err(_) => continue,
+                },
                 // If the amount results in the pool being insolvent, skip this iteration
                 Err(_) => continue,
             }

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -757,6 +757,9 @@ mod tests {
                 None,
                 None,
             );
+            // It's known that global max short is in units of bonds,
+            // but we fund bob with this amount regardless, since the amount required
+            // for deposit << the global max short number of bonds.
             bob.fund(global_max_short + fixed!(10e18));
             bob.open_short(global_max_short, None, None).await?;
 

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -147,7 +147,7 @@ impl State {
                             spot_price,
                             open_vault_share_price,
                         ));
-                // TODO this always iterates for max_iterations (unless)
+                // TODO this always iterates for max_iterations unless
                 // it makes the pool insolvent. Likely want to check an
                 // epsilon to early break
             }

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -760,7 +760,7 @@ mod tests {
             // It's known that global max short is in units of bonds,
             // but we fund bob with this amount regardless, since the amount required
             // for deposit << the global max short number of bonds.
-            bob.fund(global_max_short + fixed!(10e18));
+            bob.fund(global_max_short + fixed!(10e18)).await?;
             bob.open_short(global_max_short, None, None).await?;
 
             // Revert to the snapshot and reset the agent's wallets.

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -118,8 +118,7 @@ impl State {
         );
         let mut previous_max_bond_amount = max_bond_amount;
         let mut step_size = fixed!(1e18);
-        for i in 0..maybe_max_iterations.unwrap_or(10) {
-            println!("iteration: {}", i);
+        for _ in 0..maybe_max_iterations.unwrap_or(10) {
             let deposit = match self.calculate_open_short(
                 max_bond_amount,
                 spot_price,
@@ -149,7 +148,7 @@ impl State {
                             open_vault_share_price,
                         ));
                 // TODO this always iterates for max_iterations (unless)
-                // it makes the pool insolvent. Lilely want to check an
+                // it makes the pool insolvent. Likely want to check an
                 // epsilon to early break
             }
         }
@@ -163,7 +162,7 @@ impl State {
             panic!("max short exceeded budget");
         }
 
-        // Verify that the max bond amount is within the absolute max bond amount.
+        // Ensure that the max bond amount is within the absolute max bond amount.
         if max_bond_amount > absolute_max_bond_amount {
             max_bond_amount = absolute_max_bond_amount;
         }
@@ -700,7 +699,6 @@ mod tests {
             } else {
                 abs_diff = empirical_derivative - short_deposit_derivative;
             }
-            println!("abs_diff: {}", abs_diff);
             assert!(abs_diff < test_comparison_epsilon);
         }
 
@@ -710,6 +708,8 @@ mod tests {
     #[traced_test]
     #[tokio::test]
     async fn test_calculate_absolute_max_short_execute() -> Result<()> {
+        // Tests that the absolute max short can be executed on chain.
+
         // Spawn a test chain and create two agents -- Alice and Bob. Alice
         // is funded with a large amount of capital so that she can initialize
         // the pool. Bob is funded with a small amount of capital so that we
@@ -778,7 +778,6 @@ mod tests {
             alice.reset(Default::default());
             bob.reset(Default::default());
         }
-        assert!(false);
 
         Ok(())
     }
@@ -847,9 +846,7 @@ mod tests {
             // calculation is performed and the transaction is submitted.
             let slippage_tolerance = fixed!(0.0001e18);
             let max_short = bob.calculate_max_short(Some(slippage_tolerance)).await?;
-            println!("Calling open_short with max_short = {}", max_short);
             bob.open_short(max_short, None, None).await?;
-            println!("called");
 
             // The max short should either be equal to the global max short in
             // the case that the trader isn't budget constrained or the budget
@@ -859,7 +856,6 @@ mod tests {
                 // that the max short is always consuming at least 99.9% of
                 // the budget.
                 let error_tolerance = fixed!(0.001e18);
-                println!("checking");
                 assert!(
                     bob.base() < budget * (fixed!(1e18) - slippage_tolerance) * error_tolerance,
                     "expected (base={}) < (budget={}) * {} = {}",
@@ -875,7 +871,6 @@ mod tests {
             alice.reset(Default::default());
             bob.reset(Default::default());
         }
-        assert!(false);
 
         Ok(())
     }

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -696,13 +696,21 @@ mod tests {
                 state.vault_share_price(),
             );
 
-            let abs_diff;
+            let derivative_diff;
             if short_deposit_derivative >= empirical_derivative {
-                abs_diff = short_deposit_derivative - empirical_derivative;
+                derivative_diff = short_deposit_derivative - empirical_derivative;
             } else {
-                abs_diff = empirical_derivative - short_deposit_derivative;
+                derivative_diff = empirical_derivative - short_deposit_derivative;
             }
-            assert!(abs_diff < test_comparison_epsilon);
+            assert!(
+                derivative_diff < test_comparison_epsilon,
+                "expected (derivative_diff={}) < (test_comparison_epsilon={}), \
+                calculated_derivative={}, emperical_derivative={}",
+                derivative_diff,
+                test_comparison_epsilon,
+                derivative,
+                empirical_derivative
+            );
         }
 
         Ok(())

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -637,6 +637,9 @@ mod tests {
         Ok(())
     }
 
+    /// This test empirically tests the derivative of `short_deposit_derivative`
+    /// by calling `calculate_open_short` at two points and comparing the empirical
+    /// result with the output of `short_deposit_derivative`.
     #[traced_test]
     #[tokio::test]
     async fn test_short_deposit_derivative() -> Result<()> {
@@ -645,7 +648,7 @@ mod tests {
         // function not being monotonically increasing.
         let empirical_derivative_epsilon = fixed!(1e12);
         // TODO pretty big comparison epsilon here
-        let test_comparison_epsilon = fixed!(1e18);
+        let test_comparison_epsilon = fixed!(1e15);
 
         for _ in 0..*FAST_FUZZ_RUNS {
             let state = rng.gen::<State>();
@@ -705,15 +708,14 @@ mod tests {
         Ok(())
     }
 
+    /// Tests that the absolute max short can be executed on chain.
     #[traced_test]
     #[tokio::test]
     async fn test_calculate_absolute_max_short_execute() -> Result<()> {
-        // Tests that the absolute max short can be executed on chain.
-
         // Spawn a test chain and create two agents -- Alice and Bob. Alice
         // is funded with a large amount of capital so that she can initialize
-        // the pool. Bob is funded with a small amount of capital so that we
-        // can test `calculate_max_short` when budget is the primary constraint.
+        // the pool. Bob is funded with plenty of capital to ensure we can execute
+        // the absolute maximum short.
         let mut rng = thread_rng();
         let chain = TestChain::new(2).await?;
         let (alice, bob) = (chain.accounts()[0].clone(), chain.accounts()[1].clone());

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -708,7 +708,7 @@ mod tests {
                 calculated_derivative={}, emperical_derivative={}",
                 derivative_diff,
                 test_comparison_epsilon,
-                derivative,
+                short_deposit_derivative,
                 empirical_derivative
             );
         }

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -740,11 +740,9 @@ mod tests {
         // the pool. Bob is funded with plenty of capital to ensure we can execute
         // the absolute maximum short.
         let mut rng = thread_rng();
-        let chain = TestChain::new(2).await?;
-        let (alice, bob) = (chain.accounts()[0].clone(), chain.accounts()[1].clone());
-        let mut alice =
-            Agent::new(chain.client(alice).await?, chain.addresses().clone(), None).await?;
-        let mut bob = Agent::new(chain.client(bob).await?, chain.addresses(), None).await?;
+        let chain = TestChain::new().await?;
+        let mut alice = chain.alice().await?;
+        let mut bob = chain.bob().await?;
         let config = alice.get_config().clone();
 
         for _ in 0..*FUZZ_RUNS {

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -140,16 +140,15 @@ impl State {
                 }
             };
 
-            let derivative =
-                self.short_deposit_derivative(max_bond_amount, spot_price, open_vault_share_price);
-
             // We update the best valid max bond amount if the deposit amount
             // is valid and the current guess is better than the current estimate.
-            if (deposit < budget) && (best_valid_max_bond_amount < max_bond_amount) {
+            if deposit < budget && best_valid_max_bond_amount < max_bond_amount {
                 best_valid_max_bond_amount = max_bond_amount;
             }
 
-            // Iteratively update max_bond_amount via newton's method
+            // Iteratively update max_bond_amount via newton's method.
+            let derivative =
+                self.short_deposit_derivative(max_bond_amount, spot_price, open_vault_share_price);
             if deposit < target_budget {
                 max_bond_amount += (target_budget - deposit) / derivative;
             } else if deposit > target_budget {
@@ -179,7 +178,7 @@ impl State {
 
         // Ensure that the max bond amount is within the absolute max bond amount.
         if best_valid_max_bond_amount > absolute_max_bond_amount {
-            best_valid_max_bond_amount = absolute_max_bond_amount;
+            panic!("max short bond amount exceeded absolute max bond amount");
         }
 
         best_valid_max_bond_amount

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -763,7 +763,7 @@ mod tests {
 
             // Some of the checkpoint passes and variable interest accrues.
             alice
-                .checkpoint(alice.latest_checkpoint().await?, None)
+                .checkpoint(alice.latest_checkpoint().await?, uint256!(0), None)
                 .await?;
             let rate = rng.gen_range(fixed!(0)..=fixed!(0.5e18));
             alice

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -652,7 +652,6 @@ mod tests {
 
         for _ in 0..*FAST_FUZZ_RUNS {
             let state = rng.gen::<State>();
-            // Bind the max amount by the absolute max amount
             let amount = rng.gen_range(fixed!(10e18)..=fixed!(10_000_000e18));
 
             let p1_result = std::panic::catch_unwind(|| {
@@ -665,6 +664,7 @@ mod tests {
             let p1;
             let p2;
             match p1_result {
+                // If the amount results in the pool being insolvent, skip this iteration
                 Ok(p) => match p {
                     Ok(p) => p1 = p,
                     Err(_) => continue,
@@ -680,6 +680,7 @@ mod tests {
                 )
             });
             match p2_result {
+                // If the amount results in the pool being insolvent, skip this iteration
                 Ok(p) => match p {
                     Ok(p) => p2 = p,
                     Err(_) => continue,

--- a/crates/test-utils/src/agent.rs
+++ b/crates/test-utils/src/agent.rs
@@ -1053,7 +1053,7 @@ impl Agent<ChainClient<LocalWallet>, ChaCha8Rng> {
             open_vault_share_price,
             checkpoint_exposure,
             Some(conservative_price),
-            None,
+            Some(20),
         ))
     }
 

--- a/crates/test-utils/src/agent.rs
+++ b/crates/test-utils/src/agent.rs
@@ -1053,7 +1053,7 @@ impl Agent<ChainClient<LocalWallet>, ChaCha8Rng> {
             open_vault_share_price,
             checkpoint_exposure,
             Some(conservative_price),
-            Some(20),
+            None,
         ))
     }
 


### PR DESCRIPTION
# Resolved Issues
General updates towards https://github.com/delvtech/hyperdrive/issues/871

# Description
This PR does the following updates:
- Adds a test comparing calculated derivative of `long_amount_derivative` and `short_deposit_derivative` emperically.
    - Further work needs to be done here to decrease comparison epsilon
- Adds a test ensuring the absolute max short is a valid short size on chain.
- Implements the max short derivative calculation from https://github.com/delvtech/hyperdrive/pull/733.
- Fixes for the case where the initial max short guess made the pool insolvent.
- Fixes for convergence of `calculate_max_short`.
- ~Increasing the default number of iterations from 7 to 10 for `calculate_max_short`.~ Solved issue where we needed more iterations, so the default number of iterations is not changed.

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed. If there are
multiple reviewers, copy the checklists into sections titled `## [Reviewer Name]`.
If the PR doesn't touch Solidity and/or Rust, the corresponding checklist can
be removed.

## [[Reviewer Name]]

### Rust

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
