### PR TITLE
fix targeted long tests

### DIFF
--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -1,6 +1,6 @@
 use ethers::types::I256;
 use fixed_point::FixedPoint;
-use fixed_point_macros::{fixed, int256, uint256};
+use fixed_point_macros::{fixed, int256};
 
 use crate::{State, YieldSpace};
 

--- a/crates/hyperdrive-math/src/long/targeted.rs
+++ b/crates/hyperdrive-math/src/long/targeted.rs
@@ -501,11 +501,12 @@ mod tests {
                         let max_long = bob.calculate_max_long(None).await?;
                         let rate_after_max_long =
                             state.calculate_spot_rate_after_long(max_long, None)?;
-                        // Fail if there was a long to hit the rate (which means the max is >= the target)
-                        // Otherwise the target would have resulted in insolvency and wasn't worth it.
+                        // If the rate after the max long is at or below the target, then we could have hit it.
                         if rate_after_max_long <= target_rate {
+                            // Fail if there was a long to hit the rate (which means the max is <= the target)
                             return Err(eyre!("Calculate max long failed; a long that hits the target rate exists but was not found."));
                         }
+                        // Otherwise the target would have resulted in insolvency and wasn't possible.
                     }
                     // If the error is not the one we're looking for, return it, causing the test to fail.
                     else {

--- a/crates/hyperdrive-math/src/long/targeted.rs
+++ b/crates/hyperdrive-math/src/long/targeted.rs
@@ -154,7 +154,7 @@ impl State {
             let loss = resulting_rate - target_rate;
             if loss >= allowable_error {
                 return Err(eyre!(
-                    "get_targeted_long: Unable to find an acceptable loss. Final loss = {}.",
+                    "get_targeted_long: Unable to find an acceptable loss with max iterations. Final loss = {}.",
                     loss
                 ));
             }
@@ -380,8 +380,6 @@ impl State {
 
 #[cfg(test)]
 mod tests {
-    use std::panic;
-
     use ethers::types::U256;
     use fixed_point_macros::uint256;
     use rand::{thread_rng, Rng};
@@ -405,8 +403,8 @@ mod tests {
 
         let allowable_solvency_error = fixed!(1e5);
         let allowable_budget_error = fixed!(1e5);
-        let allowable_rate_error = fixed!(1e10);
-        let num_newton_iters = 5;
+        let allowable_rate_error = fixed!(1e11);
+        let num_newton_iters = 7;
 
         // Initialize a test chain. We don't need mocks because we want state updates.
         let chain = TestChain::new(2).await?;
@@ -479,14 +477,42 @@ mod tests {
             // Bob opens a targeted long.
             let max_spot_price_before_long = bob.get_state().await?.calculate_max_spot_price();
             let target_rate = initial_fixed_rate / fixed!(2e18);
-            let targeted_long = bob
+            let targeted_long_result = bob
                 .calculate_targeted_long(
                     target_rate,
                     Some(num_newton_iters),
                     Some(allowable_rate_error),
                 )
-                .await?;
-            bob.open_long(targeted_long, None, None).await?;
+                .await;
+
+            match targeted_long_result {
+                // If the code ran without error, open the long
+                Ok(targeted_long) => {
+                    bob.open_long(targeted_long, None, None).await?;
+                }
+
+                // Else check the error for an acceptible one
+                Err(e) => {
+                    // If the fn failed it's possible that the target rate would be insolvent.
+                    if e.to_string()
+                        .contains("Unable to find an acceptable loss with max iterations")
+                    {
+                        let state = bob.get_state().await?;
+                        let max_long = bob.calculate_max_long(None).await?;
+                        let rate_after_max_long =
+                            state.calculate_spot_rate_after_long(max_long, None)?;
+                        // Fail if there was a long to hit the rate (which means the max is >= the target)
+                        // Otherwise the target would have resulted in insolvency and wasn't worth it.
+                        if rate_after_max_long <= target_rate {
+                            return Err(eyre!("Calculate max long failed; a long that hits the target rate exists but was not found."));
+                        }
+                    }
+                    // If the error is not the one we're looking for, return it, causing the test to fail.
+                    else {
+                        return Err(e);
+                    }
+                }
+            }
 
             // Three things should be true after opening the long:
             //
@@ -530,8 +556,8 @@ mod tests {
             // and we hit the rate exactly.
             else {
                 assert!(
-                    new_rate <= target_rate,
-                    "The new_rate={} should be <= target_rate={} when budget constrained.",
+                    new_rate >= target_rate,
+                    "The new_rate={} should be >= target_rate={} when budget constrained.",
                     new_rate,
                     target_rate
                 );

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -1,6 +1,6 @@
 use ethers::types::I256;
 use fixed_point::FixedPoint;
-use fixed_point_macros::{fixed, uint256};
+use fixed_point_macros::fixed;
 
 use crate::{calculate_effective_share_reserves, State, YieldSpace};
 
@@ -533,6 +533,7 @@ mod tests {
 
     use ethers::types::U256;
     use eyre::Result;
+    use fixed_point_macros::uint256;
     use hyperdrive_wrappers::wrappers::{
         ihyperdrive::Checkpoint, mock_hyperdrive_math::MaxTradeParams,
     };


### PR DESCRIPTION
# Resolved Issues
intermittent CI crashes; no issue created

# Description

CI was crashing with intermittent errors. For example:

```
---- long::targeted::tests::test_calculate_targeted_long_with_budget stdout ----
thread 'long::targeted::tests::test_calculate_targeted_long_with_budget' panicked at crates/hyperdrive-math/src/long/targeted.rs:532:17:
The new_rate=0.065615470865036337 should be <= target_rate=0.040702128765527778 when budget constrained.


failures:
    long::targeted::tests::test_calculate_targeted_long_with_budget

test result: FAILED. 33 passed; 1 failed; 0 ignored; 0 measured; 0 filtered out; finished in 520.83s
```

This particular error was caused by an incorrect sign. In that condition, we expected that the test undershot & should raise an error on the opposite condition (the else condition presumes that we undershot, which would be `>=` instead of `<=`). 

I also added another check for an acceptable but unlikely (if not impossible in this test) failure condition where the target rate is too low, resulting in insolvency.

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed. If there are
multiple reviewers, copy the checklists into sections titled `## [Reviewer Name]`.
If the PR doesn't touch Solidity and/or Rust, the corresponding checklist can
be removed.

### Rust

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
