### PR TITLE
update calc open short & target long

### DIFF
--- a/crates/hyperdrive-math/src/long/open.rs
+++ b/crates/hyperdrive-math/src/long/open.rs
@@ -27,8 +27,7 @@ impl State {
         let base_amount = base_amount.into();
 
         if base_amount < self.config.minimum_transaction_amount.into() {
-            // TODO would be nice to return a `Result` here instead of a panic.
-            panic!("MinimumTransactionAmount: Input amount too low");
+            return Err(eyre!("MinimumTransactionAmount: Input amount too low",));
         }
 
         let long_amount =
@@ -217,9 +216,7 @@ mod tests {
     async fn test_error_open_long_min_txn_amount() -> Result<()> {
         let mut rng = thread_rng();
         let state = rng.gen::<State>();
-        let result = std::panic::catch_unwind(|| {
-            state.calculate_open_long(state.config.minimum_transaction_amount - 10)
-        });
+        let result = state.calculate_open_long(state.config.minimum_transaction_amount - 10);
         assert!(result.is_err());
         Ok(())
     }

--- a/crates/hyperdrive-math/src/long/targeted.rs
+++ b/crates/hyperdrive-math/src/long/targeted.rs
@@ -495,7 +495,8 @@ mod tests {
 
             // Get a targeted long amount.
             // TODO: explore tighter bounds on this.
-            let target_rate = initial_fixed_rate / rng.gen_range(fixed!(1.0001e18)..=fixed!(10e18));
+            let target_rate = bob.get_state().await?.calculate_spot_rate()
+                / rng.gen_range(fixed!(1.0001e18)..=fixed!(10e18));
             // let target_rate = initial_fixed_rate / fixed!(2e18);
             let targeted_long_result = bob
                 .calculate_targeted_long(

--- a/crates/hyperdrive-math/src/long/targeted.rs
+++ b/crates/hyperdrive-math/src/long/targeted.rs
@@ -51,116 +51,144 @@ impl State {
             None => fixed!(1e14),
         };
 
+        // Check input args.
+        let current_rate = self.calculate_spot_rate();
+        if target_rate > current_rate {
+            return Err(eyre!(
+                "target_rate = {} argument must be less than the current_rate = {} for a targeted long.",
+                target_rate, current_rate,
+            ));
+        }
+
         // Estimate the long that achieves a target rate.
         let (target_share_reserves, target_bond_reserves) =
             self.reserves_given_rate_ignoring_exposure(target_rate);
-        let (target_base_delta, target_bond_delta) =
+        let (mut target_base_delta, target_bond_delta) =
             self.trade_deltas_from_reserves(target_share_reserves, target_bond_reserves);
 
         // Determine what rate was achieved.
         let resulting_rate = self.rate_after_long(target_base_delta, Some(target_bond_delta))?;
 
-        // The estimated long should always underestimate because the realized price
+        // The estimated long will usually underestimate because the realized price
         // should always be greater than the spot price.
+        //
+        // However, if we overshot the zero-crossing (due to errors arising from FixedPoint arithmetic),
+        // then either return or reduce the starting base amount and start on Newton's method.
         if target_rate > resulting_rate {
-            return Err(eyre!("get_targeted_long: We overshot the zero-crossing.",));
-        }
-        let rate_error = resulting_rate - target_rate;
+            let rate_error = target_rate - resulting_rate;
 
-        // If solvent & within the allowable error, stop here.
-        if self
-            .solvency_after_long(target_base_delta, target_bond_delta, checkpoint_exposure)
-            .is_some()
-            && rate_error < allowable_error
-        {
-            Ok(target_base_delta)
-        }
-        // Else, iterate to find a solution.
-        else {
-            // We can use the initial guess as a starting point since we know it is less than the target.
-            let mut possible_target_base_delta = target_base_delta;
-
-            // Iteratively find a solution
-            for _ in 0..maybe_max_iterations.unwrap_or(7) {
-                let possible_target_bond_delta = self
-                    .calculate_open_long(possible_target_base_delta)
-                    .unwrap();
-                let resulting_rate = self.rate_after_long(
-                    possible_target_base_delta,
-                    Some(possible_target_bond_delta),
-                )?;
-
-                // We assume that the loss is positive only because Newton's
-                // method and the one-shot approximation will always underestimate.
-                if target_rate > resulting_rate {
-                    return Err(eyre!("get_targeted_long: We overshot the zero-crossing.",));
-                }
-                // The loss is $l(x) = r(x) - r_t$ for some rate after a long
-                // is opened, $r(x)$, and target rate, $r_t$.
-                let loss = resulting_rate - target_rate;
-
-                // If we've done it (solvent & within error), then return the value.
-                if self
-                    .solvency_after_long(
-                        possible_target_base_delta,
-                        possible_target_bond_delta,
-                        checkpoint_exposure,
-                    )
-                    .is_some()
-                    && loss < allowable_error
-                {
-                    return Ok(possible_target_base_delta);
-                }
-                // Otherwise perform another iteration.
-                else {
-                    // The derivative of the loss is $l'(x) = r'(x)$.
-                    // We return $-l'(x)$ because $r'(x)$ is negative, which
-                    // can't be represented with FixedPoint.
-                    let negative_loss_derivative = self.rate_after_long_derivative_negation(
-                        possible_target_base_delta,
-                        possible_target_bond_delta,
-                    )?;
-
-                    // Adding the negative loss derivative instead of subtracting the loss derivative
-                    // ∆x_{n+1} = ∆x_{n} - l / l'
-                    //          = ∆x_{n} + l / (-l')
-                    possible_target_base_delta =
-                        possible_target_base_delta + loss / negative_loss_derivative;
-                }
-            }
-
-            // Final solvency check.
+            // If we were still close enough and solvent, return.
             if self
-                .solvency_after_long(
-                    possible_target_base_delta,
-                    self.calculate_open_long(possible_target_base_delta)
-                        .unwrap(),
-                    checkpoint_exposure,
-                )
-                .is_none()
+                .solvency_after_long(target_base_delta, target_bond_delta, checkpoint_exposure)
+                .is_some()
+                && rate_error < allowable_error
             {
-                return Err(eyre!("Guess in `get_targeted_long` is insolvent."));
+                return Ok(target_base_delta);
             }
+            // Else, cut the initial guess down by an order of magnitude and go to Newton's method.
+            else {
+                target_base_delta = target_base_delta / fixed!(10e18);
+            }
+        }
+        // Else check if we are close enough to return.
+        else {
+            // If solvent & within the allowable error, stop here.
+            let rate_error = resulting_rate - target_rate;
+            if self
+                .solvency_after_long(target_base_delta, target_bond_delta, checkpoint_exposure)
+                .is_some()
+                && rate_error < allowable_error
+            {
+                return Ok(target_base_delta);
+            }
+        }
 
-            // Final accuracy check.
+        // Iterate to find a solution.
+        // We can use the initial guess as a starting point since we know it is less than the target.
+        let mut possible_target_base_delta = target_base_delta;
+
+        // Iteratively find a solution
+        for _ in 0..maybe_max_iterations.unwrap_or(7) {
             let possible_target_bond_delta = self
                 .calculate_open_long(possible_target_base_delta)
                 .unwrap();
             let resulting_rate =
                 self.rate_after_long(possible_target_base_delta, Some(possible_target_bond_delta))?;
+
+            // We assume that the loss is positive only because Newton's
+            // method and the one-shot approximation will always underestimate.
             if target_rate > resulting_rate {
-                return Err(eyre!("get_targeted_long: We overshot the zero-crossing.",));
-            }
-            let loss = resulting_rate - target_rate;
-            if loss >= allowable_error {
                 return Err(eyre!(
-                    "get_targeted_long: Unable to find an acceptable loss with max iterations. Final loss = {}.",
-                    loss
+                    "We overshot the zero-crossing during Newton's method.",
                 ));
             }
+            // The loss is $l(x) = r(x) - r_t$ for some rate after a long
+            // is opened, $r(x)$, and target rate, $r_t$.
+            let loss = resulting_rate - target_rate;
 
-            Ok(possible_target_base_delta)
+            // If we've done it (solvent & within error), then return the value.
+            if self
+                .solvency_after_long(
+                    possible_target_base_delta,
+                    possible_target_bond_delta,
+                    checkpoint_exposure,
+                )
+                .is_some()
+                && loss < allowable_error
+            {
+                return Ok(possible_target_base_delta);
+            }
+            // Otherwise perform another iteration.
+            else {
+                // The derivative of the loss is $l'(x) = r'(x)$.
+                // We return $-l'(x)$ because $r'(x)$ is negative, which
+                // can't be represented with FixedPoint.
+                let negative_loss_derivative = self.rate_after_long_derivative_negation(
+                    possible_target_base_delta,
+                    possible_target_bond_delta,
+                )?;
+
+                // Adding the negative loss derivative instead of subtracting the loss derivative
+                // ∆x_{n+1} = ∆x_{n} - l / l'
+                //          = ∆x_{n} + l / (-l')
+                possible_target_base_delta =
+                    possible_target_base_delta + loss / negative_loss_derivative;
+            }
         }
+
+        // Final solvency check.
+        if self
+            .solvency_after_long(
+                possible_target_base_delta,
+                self.calculate_open_long(possible_target_base_delta)
+                    .unwrap(),
+                checkpoint_exposure,
+            )
+            .is_none()
+        {
+            return Err(eyre!("Guess in `calculate_targeted_long` is insolvent."));
+        }
+
+        // Final accuracy check.
+        let possible_target_bond_delta = self
+            .calculate_open_long(possible_target_base_delta)
+            .unwrap();
+        let resulting_rate =
+            self.rate_after_long(possible_target_base_delta, Some(possible_target_bond_delta))?;
+        if target_rate > resulting_rate {
+            return Err(eyre!(
+                "We overshot the zero-crossing after Newton's method.",
+            ));
+        }
+        let loss = resulting_rate - target_rate;
+        if loss >= allowable_error {
+            return Err(eyre!(
+                "Unable to find an acceptable loss with max iterations. Final loss = {}.",
+                loss
+            ));
+        }
+
+        Ok(possible_target_base_delta)
     }
 
     /// The fixed rate after a long has been opened.
@@ -178,9 +206,10 @@ impl State {
     fn rate_after_long(
         &self,
         base_amount: FixedPoint,
-        bond_amount: Option<FixedPoint>,
+        maybe_bond_amount: Option<FixedPoint>,
     ) -> Result<FixedPoint> {
-        let resulting_price = self.calculate_spot_price_after_long(base_amount, bond_amount)?;
+        let resulting_price =
+            self.calculate_spot_price_after_long(base_amount, maybe_bond_amount)?;
         Ok((fixed!(1e18) - resulting_price)
             / (resulting_price * self.annualized_position_duration()))
     }
@@ -464,9 +493,10 @@ mod tests {
                 )
                 .await?;
 
-            // Bob opens a targeted long.
-            let max_spot_price_before_long = bob.get_state().await?.calculate_max_spot_price();
-            let target_rate = initial_fixed_rate / fixed!(2e18);
+            // Get a targeted long amount.
+            // TODO: explore tighter bounds on this.
+            let target_rate = initial_fixed_rate / rng.gen_range(fixed!(1.0001e18)..=fixed!(10e18));
+            // let target_rate = initial_fixed_rate / fixed!(2e18);
             let targeted_long_result = bob
                 .calculate_targeted_long(
                     target_rate,
@@ -475,6 +505,7 @@ mod tests {
                 )
                 .await;
 
+            // Bob opens a targeted long.
             match targeted_long_result {
                 // If the code ran without error, open the long
                 Ok(targeted_long) => {
@@ -513,18 +544,19 @@ mod tests {
             // 3. IF Bob's budget is not consumed; then new rate is close to the target rate
 
             // Check that our resulting price is under the max
-            let spot_price_after_long = bob.get_state().await?.calculate_spot_price();
+            let current_state = bob.get_state().await?;
+            let max_spot_price_before_long = current_state.calculate_max_spot_price();
+            let spot_price_after_long = current_state.calculate_spot_price();
             assert!(
                 max_spot_price_before_long > spot_price_after_long,
                 "Resulting price is greater than the max."
             );
 
             // Check solvency
-            let is_solvent =
-                { bob.get_state().await?.calculate_solvency() > allowable_solvency_error };
+            let is_solvent = { current_state.calculate_solvency() > allowable_solvency_error };
             assert!(is_solvent, "Resulting pool state is not solvent.");
 
-            let new_rate = bob.get_state().await?.calculate_spot_rate();
+            let new_rate = current_state.calculate_spot_rate();
             // If the budget was NOT consumed, then we assume the target was hit.
             if !(bob.base() <= allowable_budget_error) {
                 // Actual price might result in long overshooting the target.

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -177,13 +177,11 @@ mod tests {
     async fn test_error_open_short_min_txn_amount() -> Result<()> {
         let mut rng = thread_rng();
         let state = rng.gen::<State>();
-        let result = std::panic::catch_unwind(|| {
-            state.calculate_open_short(
-                (state.config.minimum_transaction_amount - 10).into(),
-                state.calculate_spot_price(),
-                state.vault_share_price(),
-            )
-        });
+        let result = state.calculate_open_short(
+            (state.config.minimum_transaction_amount - 10).into(),
+            state.calculate_spot_price(),
+            state.vault_share_price(),
+        );
         assert!(result.is_err());
         Ok(())
     }

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -1,4 +1,4 @@
-use eyre::Result;
+use eyre::{eyre, Result};
 use fixed_point::FixedPoint;
 use fixed_point_macros::fixed;
 
@@ -34,8 +34,7 @@ impl State {
         mut open_vault_share_price: FixedPoint,
     ) -> Result<FixedPoint> {
         if short_amount < self.config.minimum_transaction_amount.into() {
-            // TODO would be nice to return a `Result` here instead of a panic.
-            panic!("MinimumTransactionAmount: Input amount too low");
+            return Err(eyre!("MinimumTransactionAmount: Input amount too low",));
         }
 
         // If the open share price hasn't been set, we use the current share
@@ -52,8 +51,7 @@ impl State {
         // amount, then the trade occurred in the negative interest domain. We
         // revert in these pathological cases.
         if share_reserves_delta_in_base > short_amount {
-            // TODO would be nice to return a `Result` here instead of a panic.
-            panic!("InsufficientLiquidity: Negative Interest");
+            return Err(eyre!("InsufficientLiquidity: Negative Interest",));
         }
 
         // NOTE: The order of additions and subtractions is important to avoid underflows.
@@ -71,17 +69,18 @@ impl State {
         bond_amount: FixedPoint,
         base_amount: Option<FixedPoint>,
     ) -> Result<FixedPoint> {
-        let base_amount = match base_amount {
-            Some(base_amount) => base_amount,
-            None => self.calculate_open_short(
-                bond_amount,
-                self.calculate_spot_price(),
-                self.vault_share_price(),
-            )?,
+        let shares_amount = match base_amount {
+            Some(base_amount) => base_amount / self.vault_share_price(),
+            None => {
+                let spot_price = self.calculate_spot_price();
+                self.calculate_shares_out_given_bonds_in_down(bond_amount)
+                    - self.open_short_curve_fee(bond_amount, spot_price)
+                    + self.open_short_governance_fee(bond_amount, spot_price)
+            }
         };
         let mut state: State = self.clone();
         state.info.bond_reserves += bond_amount.into();
-        state.info.share_reserves -= (base_amount / state.vault_share_price()).into();
+        state.info.share_reserves -= shares_amount.into();
         Ok(state.calculate_spot_price())
     }
 
@@ -103,7 +102,6 @@ impl State {
 
 #[cfg(test)]
 mod tests {
-    use eyre::Result;
     use fixed_point_macros::fixed;
     use rand::{thread_rng, Rng};
     use test_utils::{chain::TestChain, constants::FUZZ_RUNS};


### PR DESCRIPTION
# Resolved Issues
partially addresses https://github.com/delvtech/hyperdrive/issues/955

# Description

- The `calculate_open_short` was written at a different time from `calculate_open_long`; I updated it so that they follow the same process.
edit: this caused trouble for reasons I can't explain but probably have to do with share/base conversions. I reverted it, but left some new error stuff.

- I also added some better error checking in `calculate_targeted_long` so that it can safely return in what was previously considered an error state.

- I added a new random test variable, the target rate itself, in the `calculate_targeted_long` tests.

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed. If there are
multiple reviewers, copy the checklists into sections titled `## [Reviewer Name]`.
If the PR doesn't touch Solidity and/or Rust, the corresponding checklist can
be removed.

## [[Reviewer Name]]

### Rust

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
