### PR TITLE
FixedPointMath 100% coverage

### DIFF
--- a/contracts/src/libraries/FixedPointMath.sol
+++ b/contracts/src/libraries/FixedPointMath.sol
@@ -318,13 +318,12 @@ library FixedPointMath {
             // min(_delta, _average) <= average <= max(_delta, _average)
             //
             // To ensure that this is always the case, we clamp the weighted
-            // average to this range.
+            // average to this range. We don't have to worry about the
+            // case where average > _delta.max(average) because rounding down when
+            // computing this average makes this case infeasible.
             uint256 minAverage = _delta.min(_average);
-            uint256 maxAverage = _delta.max(_average);
             if (average < minAverage) {
                 average = minAverage;
-            } else if (average > maxAverage) {
-                average = maxAverage;
             }
         }
         // If the delta weight should be subtracted from the total weight, we

--- a/test/units/libraries/FixedPointMath.t.sol
+++ b/test/units/libraries/FixedPointMath.t.sol
@@ -240,6 +240,16 @@ contract FixedPointMathTest is Test {
             ),
             1e18
         );
+        assertEq(
+            mockFixedPointMath.updateWeightedAverage(
+                100e18,
+                10e18,
+                200e18,
+                10e18,
+                true
+            ),
+            150e18
+        );
     }
 
     // This test verifies that update weighted average always performs as a


### PR DESCRIPTION
# Description
Removed infeasible branch condition in `calculateWeightedAverage()` per Certora report. This should get fixed point math to 100% coverage.

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
