### PR TITLE
Fixing bug in average time remaining calculation in present value

### DIFF
--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -89,10 +89,10 @@ impl Distribution<State> for Standard {
                 }
             },
             long_average_maturity_time: rng
-                .gen_range(fixed!(0)..=FixedPoint::from(60 * 60 * 24 * 365) * fixed!(1e18))
+                .gen_range(fixed!(0)..=FixedPoint::from(config.position_duration) * fixed!(1e18))
                 .into(),
             short_average_maturity_time: rng
-                .gen_range(fixed!(0)..=FixedPoint::from(60 * 60 * 24 * 365) * fixed!(1e18))
+                .gen_range(fixed!(0)..=FixedPoint::from(config.position_duration) * fixed!(1e18))
                 .into(),
             lp_total_supply: rng
                 .gen_range(fixed!(1_000e18)..=fixed!(100_000_000e18))

--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -88,11 +88,13 @@ impl Distribution<State> for Standard {
                     .unwrap()
                 }
             },
+            // If this range returns greater than position duration, then both rust and solidity will fail
+            // on calls that depend on this value.
             long_average_maturity_time: rng
-                .gen_range(fixed!(0)..=FixedPoint::from(config.position_duration) * fixed!(1e18))
+                .gen_range(fixed!(0)..=FixedPoint::from(365 * one_day_in_seconds) * fixed!(1e18))
                 .into(),
             short_average_maturity_time: rng
-                .gen_range(fixed!(0)..=FixedPoint::from(config.position_duration) * fixed!(1e18))
+                .gen_range(fixed!(0)..=FixedPoint::from(365 * one_day_in_seconds) * fixed!(1e18))
                 .into(),
             lp_total_supply: rng
                 .gen_range(fixed!(1_000e18)..=fixed!(100_000_000e18))

--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -89,10 +89,10 @@ impl Distribution<State> for Standard {
                 }
             },
             long_average_maturity_time: rng
-                .gen_range(fixed!(0)..=FixedPoint::from(60 * 60 * 24 * 365))
+                .gen_range(fixed!(0)..=FixedPoint::from(60 * 60 * 24 * 365) * fixed!(1e18))
                 .into(),
             short_average_maturity_time: rng
-                .gen_range(fixed!(0)..=FixedPoint::from(60 * 60 * 24 * 365))
+                .gen_range(fixed!(0)..=FixedPoint::from(60 * 60 * 24 * 365) * fixed!(1e18))
                 .into(),
             lp_total_supply: rng
                 .gen_range(fixed!(1_000e18)..=fixed!(100_000_000e18))

--- a/crates/hyperdrive-math/src/lp.rs
+++ b/crates/hyperdrive-math/src/lp.rs
@@ -172,6 +172,25 @@ impl State {
         idle_shares_in_base
     }
 
+    /// Function that takes in a scaled FixedPoint maturity time and calculates
+    /// normalized time remaining with higher precision.
+    fn calculate_scaled_normalized_time_remaining(
+        &self,
+        scaled_maturity_time: FixedPoint,
+        current_time: U256,
+    ) -> FixedPoint {
+        let scaled_latest_checkpoint =
+            FixedPoint::from(self.to_checkpoint(current_time)) * fixed!(1e36);
+        let scaled_position_duration = self.position_duration() * fixed!(1e36);
+        if scaled_maturity_time > scaled_latest_checkpoint {
+            // NOTE: Round down to underestimate the time remaining.
+            FixedPoint::from(scaled_maturity_time - scaled_latest_checkpoint)
+                .div_down(scaled_position_duration)
+        } else {
+            fixed!(0)
+        }
+    }
+
     /// Calculates the present value of LPs capital in the pool.
     pub fn calculate_present_value(&self, current_block_timestamp: U256) -> FixedPoint {
         // Calculate the average time remaining for the longs and shorts.
@@ -179,28 +198,14 @@ impl State {
         // To keep precision of long and short average maturity time (from contract call)
         // we scale the block timestamp and position duration by 1e18 to calculate
         // the normalized time remaining.
-        let scaled_latest_checkpoint =
-            FixedPoint::from(self.to_checkpoint(current_block_timestamp)) * fixed!(1e36);
-        let scaled_position_duration = self.position_duration() * fixed!(1e36);
-        let long_average_maturity_time = self.long_average_maturity_time();
-        let short_average_maturity_time = self.short_average_maturity_time();
-
-        let long_average_time_remaining = if long_average_maturity_time > scaled_latest_checkpoint {
-            // NOTE: Round down to underestimate the time remaining.
-            FixedPoint::from(long_average_maturity_time - scaled_latest_checkpoint)
-                .div_down(scaled_position_duration)
-        } else {
-            fixed!(0)
-        };
-
-        let short_average_time_remaining = if short_average_maturity_time > scaled_latest_checkpoint
-        {
-            // NOTE: Round down to underestimate the time remaining.
-            FixedPoint::from(short_average_maturity_time - scaled_latest_checkpoint)
-                .div_down(scaled_position_duration)
-        } else {
-            fixed!(0)
-        };
+        let long_average_time_remaining = self.calculate_scaled_normalized_time_remaining(
+            self.long_average_maturity_time(),
+            current_block_timestamp,
+        );
+        let short_average_time_remaining = self.calculate_scaled_normalized_time_remaining(
+            self.short_average_maturity_time(),
+            current_block_timestamp,
+        );
 
         let present_value: I256 = I256::try_from(self.share_reserves()).unwrap()
             + self.calculate_net_curve_trade(
@@ -550,14 +555,14 @@ mod tests {
                     minimum_share_reserves: state.config.minimum_share_reserves,
                     minimum_transaction_amount: state.config.minimum_transaction_amount,
                     long_average_time_remaining: state
-                        .calculate_normalized_time_remaining(
-                            state.long_average_maturity_time().into(),
+                        .calculate_scaled_normalized_time_remaining(
+                            state.long_average_maturity_time(),
                             current_block_timestamp.into(),
                         )
                         .into(),
                     short_average_time_remaining: state
-                        .calculate_normalized_time_remaining(
-                            state.short_average_maturity_time().into(),
+                        .calculate_scaled_normalized_time_remaining(
+                            state.short_average_maturity_time(),
                             current_block_timestamp.into(),
                         )
                         .into(),

--- a/crates/hyperdrive-math/src/lp.rs
+++ b/crates/hyperdrive-math/src/lp.rs
@@ -180,8 +180,8 @@ impl State {
         // we scale the block timestamp and position duration by 1e18 to calculate
         // the normalized time remaining.
         let scaled_latest_checkpoint =
-            FixedPoint::from(self.to_checkpoint(current_block_timestamp)) * fixed!(1e18);
-        let scaled_position_duration = self.position_duration() * fixed!(1e18);
+            FixedPoint::from(self.to_checkpoint(current_block_timestamp)) * fixed!(1e36);
+        let scaled_position_duration = self.position_duration() * fixed!(1e36);
         let long_average_maturity_time = self.long_average_maturity_time();
         let short_average_maturity_time = self.short_average_maturity_time();
 


### PR DESCRIPTION
# Resolved Issues
- State generation for `long_average_maturity_time` and `short_average_maturity_time` in tests do not cover full range of possible values, due to the underlying fields in pool info being scaled by 1e18.
- Fixing time remaining calculation in `calculate_present_value` to account for average maturity time being scaled.

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed. If there are
multiple reviewers, copy the checklists into sections titled `## [Reviewer Name]`.
If the PR doesn't touch Solidity and/or Rust, the corresponding checklist can
be removed.

## [[Reviewer Name]]

### Rust

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
