### PR TITLE
update `calc_open_short` to match solidity

### DIFF
--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -394,37 +394,6 @@ impl State {
                 + self.governance_lp_fee() * self.curve_fee() * (fixed!(1e18) - spot_price))
     }
 
-    /// Calculates the derivative of the short deposit function with respect to the
-    /// short amount. This allows us to use Newton's method to approximate the
-    /// maximum short that a trader can open.
-    ///
-    /// Using this, calculating $D'(x)$ is straightforward:
-    ///
-    /// $$
-    /// D'(x) = \tfrac{c}{c_0} - (c \cdot P'(x) - \phi_{curve} \cdot (1 - p)) + \phi_{flat}
-    /// $$
-    ///
-    /// $$
-    /// P'(x) = \tfrac{1}{c} \cdot (y + x)^{-t_s} \cdot \left(\tfrac{\mu}{c} \cdot (k - (y + x)^{1 - t_s}) \right)^{\tfrac{t_s}{1 - t_s}}
-    /// $$
-    fn short_deposit_derivative(
-        &self,
-        bond_amount: FixedPoint,
-        spot_price: FixedPoint,
-        open_vault_share_price: FixedPoint,
-    ) -> FixedPoint {
-        // NOTE: The order of additions and subtractions is important to avoid underflows.
-        let payment_factor = (fixed!(1e18)
-            / (self.bond_reserves() + bond_amount).pow(self.time_stretch()))
-            * self
-                .theta(bond_amount)
-                .pow(self.time_stretch() / (fixed!(1e18) - self.time_stretch()));
-        (self.vault_share_price() / open_vault_share_price)
-            + self.flat_fee()
-            + self.curve_fee() * (fixed!(1e18) - spot_price)
-            - payment_factor
-    }
-
     /// Calculates the pool's solvency after opening a short.
     ///
     /// We can express the pool's solvency after opening a short of $x$ bonds as:
@@ -514,21 +483,6 @@ impl State {
             None
         }
     }
-
-    /// A helper function used in calculating the short deposit.
-    ///
-    /// This calculates the inner component of the `short_principal` calculation,
-    /// which makes the `short_principal` and `short_deposit_derivative` calculations
-    /// easier. $\theta(x)$ is defined as:
-    ///
-    /// $$
-    /// \theta(x) = \tfrac{\mu}{c} \cdot (k - (y + x)^{1 - t_s})
-    /// $$
-    fn theta(&self, bond_amount: FixedPoint) -> FixedPoint {
-        (self.initial_vault_share_price() / self.vault_share_price())
-            * (self.k_down()
-                - (self.bond_reserves() + bond_amount).pow(fixed!(1e18) - self.time_stretch()))
-    }
 }
 
 #[cfg(test)]
@@ -611,84 +565,6 @@ mod tests {
                 }
                 Err(_) => assert!(actual.is_err()),
             }
-        }
-
-        Ok(())
-    }
-
-    /// This test empirically tests the derivative of `short_deposit_derivative`
-    /// by calling `calculate_open_short` at two points and comparing the empirical
-    /// result with the output of `short_deposit_derivative`.
-    #[traced_test]
-    #[tokio::test]
-    async fn fuzz_short_deposit_derivative() -> Result<()> {
-        let mut rng = thread_rng();
-        // We use a relatively large epsilon here due to the underlying fixed point pow
-        // function not being monotonically increasing.
-        let empirical_derivative_epsilon = fixed!(1e12);
-        // TODO pretty big comparison epsilon here
-        let test_comparison_epsilon = fixed!(1e15);
-
-        for _ in 0..*FAST_FUZZ_RUNS {
-            let state = rng.gen::<State>();
-            let amount = rng.gen_range(fixed!(10e18)..=fixed!(10_000_000e18));
-
-            let p1_result = std::panic::catch_unwind(|| {
-                state.calculate_open_short(
-                    amount - empirical_derivative_epsilon,
-                    state.vault_share_price(),
-                )
-            });
-            let p1;
-            let p2;
-            match p1_result {
-                // If the amount results in the pool being insolvent, skip this iteration
-                Ok(p) => match p {
-                    Ok(p) => p1 = p,
-                    Err(_) => continue,
-                },
-                Err(_) => continue,
-            }
-
-            let p2_result = std::panic::catch_unwind(|| {
-                state.calculate_open_short(
-                    amount + empirical_derivative_epsilon,
-                    state.vault_share_price(),
-                )
-            });
-            match p2_result {
-                // If the amount results in the pool being insolvent, skip this iteration
-                Ok(p) => match p {
-                    Ok(p) => p2 = p,
-                    Err(_) => continue,
-                },
-                Err(_) => continue,
-            }
-            // Sanity check
-            assert!(p2 > p1);
-
-            let empirical_derivative = (p2 - p1) / (fixed!(2e18) * empirical_derivative_epsilon);
-            let short_deposit_derivative = state.short_deposit_derivative(
-                amount,
-                state.calculate_spot_price(),
-                state.vault_share_price(),
-            );
-
-            let derivative_diff;
-            if short_deposit_derivative >= empirical_derivative {
-                derivative_diff = short_deposit_derivative - empirical_derivative;
-            } else {
-                derivative_diff = empirical_derivative - short_deposit_derivative;
-            }
-            assert!(
-                derivative_diff < test_comparison_epsilon,
-                "expected (derivative_diff={}) < (test_comparison_epsilon={}), \
-                calculated_derivative={}, emperical_derivative={}",
-                derivative_diff,
-                test_comparison_epsilon,
-                short_deposit_derivative,
-                empirical_derivative
-            );
         }
 
         Ok(())

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -19,13 +19,13 @@ impl State {
     /// function as:
     ///
     /// $$
-    /// D(x) = \Delta y - (c \cdot P(x) - \phi_{curve} \cdot (1 - p) \cdot \Delta y)
+    /// D(\Delta y) = \Delta y - (c \cdot P(x) - \phi_{curve} \cdot (1 - p) \cdot \Delta y)
     ///        + (c - c_0) \cdot \tfrac{\Delta y}{c_0} + \phi_{flat} \cdot \Delta y \\
-    ///      = \tfrac{c}{c_0} \cdot \Delta y - (c \cdot P(x) - \phi_{curve} \cdot (1 - p) \cdot \Delta y)
+    ///      = \tfrac{c}{c_0} \cdot \Delta y - (c \cdot P(\Delta y) - \phi_{curve} \cdot (1 - p) \cdot \Delta y)
     ///        + \phi_{flat} \cdot \Delta y
     /// $$
     ///
-    /// $x$ is the number of bonds being shorted and $P(x)$ is the amount of
+    /// $\Delta y$ is the number of bonds being shorted and $P(\Delta y)$ is the amount of
     /// shares the curve says the LPs need to pay the shorts (i.e. the LP
     /// principal).
     pub fn calculate_open_short(
@@ -232,22 +232,22 @@ impl State {
     /// solve for this in terms of $x$ using the YieldSpace invariant:
     ///
     /// $$
-    /// k = \tfrac{c}{\mu} \cdot (\mu \cdot (z - P(x)))^{1 - t_s} + (y + x)^{1 - t_s} \\
+    /// k = \tfrac{c}{\mu} \cdot (\mu \cdot (z - P(\Delta y)))^{1 - t_s} + (y + \Delta y)^{1 - t_s} \\
     /// \implies \\
-    /// P(x) = z - \tfrac{1}{\mu} \cdot (\tfrac{\mu}{c} \cdot (k - (y + x)^{1 - t_s}))^{\tfrac{1}{1 - t_s}}
+    /// P(\Delta y) = z - \tfrac{1}{\mu} \cdot (\tfrac{\mu}{c} \cdot (k - (y + \Delta y)^{1 - t_s}))^{\tfrac{1}{1 - t_s}}
     /// $$
     pub fn calculate_short_principal(&self, bond_amount: FixedPoint) -> Result<FixedPoint> {
         self.calculate_shares_out_given_bonds_in_down_safe(bond_amount)
     }
 
-    /// Calculates the derivative of the short principal $P(x)$ w.r.t. the amount of
-    /// bonds that are shorted $x$.
+    /// Calculates the derivative of the short principal $P(\Delta y)$ w.r.t. the amount of
+    /// bonds that are shorted $\Delta y$.
     ///
     /// The derivative is calculated as:
     ///
     /// $$
-    /// P'(x) = \tfrac{1}{c} \cdot (y + x)^{-t_s} \cdot \left(
-    ///             \tfrac{\mu}{c} \cdot (k - (y + x)^{1 - t_s})
+    /// P'(\Delta y) = \tfrac{1}{c} \cdot (y + \Delta y)^{-t_s} \cdot \left(
+    ///             \tfrac{\mu}{c} \cdot (k - (y + \Delta y)^{1 - t_s})
     ///         \right)^{\tfrac{t_s}{1 - t_s}}
     /// $$
     pub fn calculate_short_principal_derivative(&self, bond_amount: FixedPoint) -> FixedPoint {

--- a/crates/hyperdrive-math/tests/integration_tests.rs
+++ b/crates/hyperdrive-math/tests/integration_tests.rs
@@ -116,7 +116,7 @@ pub async fn test_integration_calculate_max_short() -> Result<()> {
             checkpoint_exposure,
             None,
             None,
-        );
+        )?;
         let budget = bob.base();
         let slippage_tolerance = fixed!(0.001e18);
         let max_short = bob.calculate_max_short(Some(slippage_tolerance)).await?;

--- a/crates/test-utils/src/agent.rs
+++ b/crates/test-utils/src/agent.rs
@@ -1058,7 +1058,7 @@ impl Agent<ChainClient<LocalWallet>, ChaCha8Rng> {
             checkpoint_exposure,
             Some(conservative_price),
             None,
-        ))
+        )?)
     }
 
     // TODO: We'll need to implement helpers that give us the maximum trade


### PR DESCRIPTION
# Resolved Issues
https://github.com/delvtech/hyperdrive-rs/issues/29

# Description
<img width="489" alt="image" src="https://github.com/delvtech/hyperdrive/assets/153468/4e13502c-3292-48fb-9a65-cbd72d4343d0">


# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed. If there are
multiple reviewers, copy the checklists into sections titled `## [Reviewer Name]`.
If the PR doesn't touch Solidity and/or Rust, the corresponding checklist can
be removed.

## [[Reviewer Name]]

### Rust

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
