### PR TITLE
Adds an implied rate calculation to the Rust SDK

### DIFF
--- a/crates/hyperdrive-math/src/lib.rs
+++ b/crates/hyperdrive-math/src/lib.rs
@@ -243,7 +243,7 @@ impl State {
 
     /// Info ///
 
-    fn vault_share_price(&self) -> FixedPoint {
+    pub fn vault_share_price(&self) -> FixedPoint {
         self.info.vault_share_price.into()
     }
 

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -131,11 +131,7 @@ impl State {
         open_vault_share_price: FixedPoint,
         variable_apy: FixedPoint,
     ) -> Result<I256> {
-        let base_paid = self.calculate_open_short(
-            bond_amount,
-            self.calculate_spot_price(),
-            open_vault_share_price,
-        )?;
+        let base_paid = self.calculate_open_short(bond_amount, open_vault_share_price)?;
         let base_proceeds = bond_amount * variable_apy;
         if base_proceeds > base_paid {
             Ok(I256::try_from((base_proceeds - base_paid) / base_paid)?)


### PR DESCRIPTION
# Resolved Issues

Fixes: #996.

# Description

Adds an implied rate calculation to the Rust SDK.

# Review Checklists

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
