### PR TITLE
test negative zeta adjustment

### DIFF
--- a/contracts/test/MockHyperdriveMath.sol
+++ b/contracts/test/MockHyperdriveMath.sol
@@ -22,6 +22,17 @@ contract MockHyperdriveMath {
         return result;
     }
 
+    function calculateEffectiveShareReserves(
+        uint256 _shareReserves,
+        int256 _shareAdjustment
+    ) external pure returns (uint256) {
+        uint256 result = HyperdriveMath.calculateEffectiveShareReserves(
+            _shareReserves,
+            _shareAdjustment
+        );
+        return result;
+    }
+
     function calculateInitialBondReserves(
         uint256 _effectiveShareReserves,
         uint256 _initialVaultSharePrice,

--- a/test/units/libraries/HyperdriveMath.t.sol
+++ b/test/units/libraries/HyperdriveMath.t.sol
@@ -19,6 +19,36 @@ contract HyperdriveMathTest is HyperdriveTest {
 
     uint256 internal constant PRECISION_THRESHOLD = 1e14;
 
+    function test__calculateEffectiveShareReserves() external {
+        // NOTE: Coverage only works if I initialize the fixture in the test function
+        MockHyperdriveMath hyperdriveMath = new MockHyperdriveMath();
+
+        // Test effective share reserves equal to zero.
+        assertEq(
+            hyperdriveMath.calculateEffectiveShareReserves(
+                1 ether, // shareReserves
+                1 ether // shareAdjustment
+            ),
+            0 ether
+        );
+
+        // Test effective share reserves greater than zero.
+        assertEq(
+            hyperdriveMath.calculateEffectiveShareReserves(
+                2 ether, // shareReserves
+                1 ether // shareAdjustment
+            ),
+            1 ether
+        );
+
+        // Test effective share reserves less than zero
+        vm.expectRevert(IHyperdrive.InsufficientLiquidity.selector);
+        hyperdriveMath.calculateEffectiveShareReserves(
+            1 ether, // shareReserves
+            2 ether // shareAdjustment
+        );
+    }
+
     function test__calcSpotPrice() external {
         // NOTE: Coverage only works if I initialize the fixture in the test function
         MockHyperdriveMath hyperdriveMath = new MockHyperdriveMath();


### PR DESCRIPTION
# Description

This should bump coverage in Hyperdrive Math

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?

