### PR TITLE
Various bug fixes in rust sdk

### DIFF
--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -146,6 +146,11 @@ impl State {
             }
         }
 
+        // If the max base amount is less than the minimum transaction amount, we return 0 as the max long.
+        if max_base_amount <= self.minimum_transaction_amount() {
+            return fixed!(0);
+        }
+
         // Ensure that the final result is less than the absolute max and clamp
         // to the budget.
         if max_base_amount >= absolute_max_base_amount {

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -545,7 +545,7 @@ mod tests {
                 }
                 Err(_) => assert!(
                     // Check both panic and err
-                    actual.is_err() or actual.unwrap().is_err()
+                    actual.is_err() || actual.unwrap().is_err()
                 ),
             }
         }

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -118,7 +118,15 @@ impl State {
             if maybe_derivative.is_none() {
                 break;
             }
-            let possible_max_base_amount = max_base_amount + solvency / maybe_derivative.unwrap();
+            let mut possible_max_base_amount =
+                max_base_amount + solvency / maybe_derivative.unwrap();
+
+            // possible_max_base_amount might be less than minimum transaction amount.
+            // we clamp here if so
+            if possible_max_base_amount < self.minimum_transaction_amount() {
+                possible_max_base_amount = self.minimum_transaction_amount();
+            }
+
             maybe_solvency = self.solvency_after_long(
                 possible_max_base_amount,
                 self.calculate_open_long(possible_max_base_amount).unwrap(),

--- a/crates/hyperdrive-math/src/long/max.rs
+++ b/crates/hyperdrive-math/src/long/max.rs
@@ -81,6 +81,12 @@ impl State {
         // we converge to the solution.
         let mut max_base_amount =
             self.max_long_guess(absolute_max_base_amount, checkpoint_exposure);
+
+        // possible_max_base_amount might be less than minimum transaction amount.
+        // we clamp here if so
+        if max_base_amount < self.minimum_transaction_amount() {
+            max_base_amount = self.minimum_transaction_amount();
+        }
         let mut maybe_solvency = self.solvency_after_long(
             max_base_amount,
             self.calculate_open_long(max_base_amount).unwrap(),

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -318,12 +318,12 @@ impl State {
         let mut maybe_solvency =
             self.solvency_after_short(max_bond_amount, spot_price, checkpoint_exposure);
         if maybe_solvency.is_none() {
-            // If initial guess is insolvant, use the absolute max short
+            // If initial guess is insolvent, use the absolute max short
             // as the initial guess
             max_bond_amount = absolute_max_bond_amount;
             // We expect by definition for the pool to be solvent with the absolute max bond amount.
             maybe_solvency =
-                self.solvency_after_short(max_bond_amount, spot_price, checkpoint_exposure)
+                self.solvency_after_short(max_bond_amount, spot_price, checkpoint_exposure);
         }
         let mut solvency = maybe_solvency.unwrap();
         for _ in 0..maybe_max_iterations.unwrap_or(7) {

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -318,12 +318,7 @@ impl State {
         let mut maybe_solvency =
             self.solvency_after_short(max_bond_amount, spot_price, checkpoint_exposure);
         if maybe_solvency.is_none() {
-            // If initial guess is insolvent, use the absolute max short
-            // as the initial guess
-            max_bond_amount = absolute_max_bond_amount;
-            // We expect by definition for the pool to be solvent with the absolute max bond amount.
-            maybe_solvency =
-                self.solvency_after_short(max_bond_amount, spot_price, checkpoint_exposure);
+            panic!("Initial guess in `absolute_max_short` is insolvent.");
         }
         let mut solvency = maybe_solvency.unwrap();
         for _ in 0..maybe_max_iterations.unwrap_or(7) {

--- a/crates/hyperdrive-math/src/short/max.rs
+++ b/crates/hyperdrive-math/src/short/max.rs
@@ -318,7 +318,12 @@ impl State {
         let mut maybe_solvency =
             self.solvency_after_short(max_bond_amount, spot_price, checkpoint_exposure);
         if maybe_solvency.is_none() {
-            panic!("Initial guess in `max_short` is insolvent.");
+            // If initial guess is insolvant, use the absolute max short
+            // as the initial guess
+            max_bond_amount = absolute_max_bond_amount;
+            // We expect by definition for the pool to be solvent with the absolute max bond amount.
+            maybe_solvency =
+                self.solvency_after_short(max_bond_amount, spot_price, checkpoint_exposure)
         }
         let mut solvency = maybe_solvency.unwrap();
         for _ in 0..maybe_max_iterations.unwrap_or(7) {


### PR DESCRIPTION
# Resolved Issues
This solves various rust crashes resulting from python fuzz testing.
https://github.com/delvtech/hyperdrive/issues/1004

# Description
Fixes the following issues:
- Max long guesses is below the minimum transaction amount, so `calc_open_long` throws a minimum transaction amount error. We clamp the guess to be minimum transaction amount. and do a final check at the end to ensure the max amount is greater than the minimum transaction amount.
- We catch a case in `absolute_max_long` where the `target_share_reserves < effective_share_reserves`. In this case, we throw an error in `absolute_max_long`, and catch it and return 0 in `calc_max_long`.

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed. If there are
multiple reviewers, copy the checklists into sections titled `## [Reviewer Name]`.
If the PR doesn't touch Solidity and/or Rust, the corresponding checklist can
be removed.

## [[Reviewer Name]]

### Rust

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
