### PR TITLE
fix calculate_implied_rate to scale according to position duration

### DIFF
--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -152,16 +152,16 @@ impl State {
     /// $$
     /// r_{implied} = \frac{r_{variable} - r_{effective}}{r_{effective}}
     /// $$
-    /// 
+    ///
     /// We can short-cut this calculation using the amount of base the short
     /// will pay and comparing this to the amount of base the short will receive
     /// if the variable rate stays the same. The implied rate is just the ROI
     /// if the variable rate stays the same.
-    /// 
+    ///
     /// To do this, we must adjust the variable rate $r_{adjusted}$ according to
     /// the position duration $t$ and the variable yield source's compounding
     /// frequency $f$. The adjusted rate will be:
-    /// 
+    ///
     /// $$
     /// r_{adjusted} = ((1 + r_{variable})^{1/f})^{t*f}-1
     /// $$
@@ -174,10 +174,9 @@ impl State {
     ) -> Result<I256> {
         let base_paid = self.calculate_open_short(bond_amount, open_vault_share_price)?;
         let base_proceeds = bond_amount
-            * (((fixed!(1e18) + variable_apy)
-            .pow(fixed!(1e18) / compounding_frequency))
-            .pow(self.annualized_position_duration() * compounding_frequency)
-            - fixed!(1e18));
+            * (((fixed!(1e18) + variable_apy).pow(fixed!(1e18) / compounding_frequency))
+                .pow(self.annualized_position_duration() * compounding_frequency)
+                - fixed!(1e18));
         if base_proceeds > base_paid {
             Ok(I256::try_from((base_proceeds - base_paid) / base_paid)?)
         } else {

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -159,8 +159,8 @@ impl State {
     /// if the variable rate stays the same.
     /// 
     /// To do this, we must adjust the variable rate $r_{adjusted}$ according to
-    /// the position duration and the variable yield source's compounding
-    /// intervals. The adjusted rate will be:
+    /// the position duration $t$ and the variable yield source's compounding
+    /// frequency $f$. The adjusted rate will be:
     /// 
     /// $$
     /// r_{adjusted} = ((1 + r_{variable})^{1/f})^{t*f}-1

--- a/crates/hyperdrive-math/src/short/open.rs
+++ b/crates/hyperdrive-math/src/short/open.rs
@@ -175,7 +175,7 @@ impl State {
         let base_paid = self.calculate_open_short(bond_amount, open_vault_share_price)?;
         let base_proceeds = bond_amount
             * (((fixed!(1e18) + variable_apy)
-            .pow(fixed!(1e18) / (fixed!(1e18) * compounding_frequency)))
+            .pow(fixed!(1e18) / compounding_frequency))
             .pow(self.annualized_position_duration() * compounding_frequency)
             - fixed!(1e18));
         if base_proceeds > base_paid {


### PR DESCRIPTION
# Resolved Issues
Fixes #1003 

# Description
Fixes calculate_implied_rate to adjust the variable rate according to the term duration and compounding frequency.

We should probably add a test with a position duration different than 1 year, but I couldn't easily figure out how to. 

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed. If there are
multiple reviewers, copy the checklists into sections titled `## [Reviewer Name]`.
If the PR doesn't touch Solidity and/or Rust, the corresponding checklist can
be removed.

## [[Reviewer Name]]

### Rust

- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
    - [ ] If matching Solidity behavior, are there differential fuzz tests that
          ensure that Rust matches Solidity?
