### PR TITLE
Use the previous weighted spot price instead of the current weighted spot price for `addLiquidity`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ deployments/
 
 # etherscan debugging
 etherscan_requests/
+
+# todos
+TODO.md

--- a/contracts/src/internal/HyperdriveLP.sol
+++ b/contracts/src/internal/HyperdriveLP.sol
@@ -203,14 +203,16 @@ abstract contract HyperdriveLP is
         // Ensure that the spot APR is close enough to the previous weighted
         // spot price to fall within the tolerance.
         {
-            uint256 weightedSpotAPR = HyperdriveMath.calculateAPRFromPrice(
-                _checkpoints[latestCheckpoint].weightedSpotPrice,
-                _positionDuration
-            );
+            uint256 previousWeightedSpotAPR = HyperdriveMath
+                .calculateAPRFromPrice(
+                    _checkpoints[latestCheckpoint - _checkpointDuration]
+                        .weightedSpotPrice,
+                    _positionDuration
+                );
             if (
-                apr > weightedSpotAPR + _circuitBreakerDelta ||
-                (weightedSpotAPR > _circuitBreakerDelta &&
-                    apr < weightedSpotAPR - _circuitBreakerDelta)
+                apr > previousWeightedSpotAPR + _circuitBreakerDelta ||
+                (previousWeightedSpotAPR > _circuitBreakerDelta &&
+                    apr < previousWeightedSpotAPR - _circuitBreakerDelta)
             ) {
                 revert IHyperdrive.CircuitBreakerTriggered();
             }

--- a/test/integrations/hyperdrive/CircuitBreakerTest.t.sol
+++ b/test/integrations/hyperdrive/CircuitBreakerTest.t.sol
@@ -118,7 +118,7 @@ contract CircuitBreakerTest is HyperdriveTest {
                 timeStretchFixedRate,
                 POSITION_DURATION
             );
-            config.circuitBreakerDelta = 1e18;
+            config.circuitBreakerDelta = 0.01e18; // 1% circuit breaker delta
             deploy(alice, config);
             uint256 contribution = 10_000_000e18;
             initialize(alice, fixedRate, contribution);
@@ -131,7 +131,10 @@ contract CircuitBreakerTest is HyperdriveTest {
             openLong(bob, longSize);
 
             // Advance time to near the end of the current checkpoint.
-            advanceTime(0.99e18, 0);
+            advanceTime(CHECKPOINT_DURATION.mulDown(0.99e18), 0);
+
+            // Open a small trade to update the weighted spot price.
+            openShort(bob, MINIMUM_TRANSACTION_AMOUNT);
 
             // Add liquidity should revert because the weighted spot apr
             // is greater than the delta and the spot apr is less than


### PR DESCRIPTION
# Resolved Issues

Fixes: https://github.com/spearbit-audits/delv-week-review/issues/13

# Description

This PR adds some tests to make sure that the weighted spot price behaves as expected with instantaneous trades and fixes an oversight where the current weighted spot price is used for the `addLiquidity` check instead of the previous weighted spot price.

The previous weighted spot price will never be `0` in `addLiquidity` because the current checkpoint is always minted with [`_applyCheckpoint`](https://github.com/delvtech/hyperdrive/blob/e5525e96fea5bc61e0eec7fe694049aa6722aa1c/contracts/src/internal/HyperdriveLP.sol#L196). In `_applyCheckpoint`, we always [update the previous weighted spot price](https://github.com/delvtech/hyperdrive/blob/e5525e96fea5bc61e0eec7fe694049aa6722aa1c/contracts/src/internal/HyperdriveCheckpoint.sol#L157). This uses the current spot price for the update, so unless the current spot price is `0`, the weighted spot price will be non-zero. Some tests were added to clarify this.

# Review Checklists

Please check each item **before approving** the pull request. While going
through the checklist, it is recommended to leave comments on items that are
referenced in the checklist to make sure that they are reviewed. If there are
multiple reviewers, copy the checklists into sections titled `## [Reviewer Name]`.
If the PR doesn't touch Solidity, the corresponding checklist can
be removed.

## [[Reviewer Name]]

- [ ] **Tokens**
    - [ ] Do all `approve` calls use `forceApprove`?
    - [ ] Do all `transfer` calls use `safeTransfer`?
    - [ ] Do all `transferFrom` calls use `msg.sender` as the `from` address?
        - [ ] If not, is the function access restricted to prevent unauthorized
              token spend?
- [ ] **Low-level calls (`call`, `delegatecall`, `staticcall`, `transfer`, `send`)**
    - [ ] Is the returned `success` boolean checked to handle failed calls?
    - [ ] If using `delegatecall`, are there strict access controls on the
          addresses that can be called? It shouldn't be possible to `delegatecall`
          arbitrary addresses, so the list of possible targets should either be
          immutable or tightly controlled by an admin.
- [ ] **Reentrancy**
    - [ ] Are functions that make external calls or transfer ether marked as `nonReentrant`?
        - [ ] If not, is there documentation that explains why reentrancy is
              not a concern or how it's mitigated?
- [ ] **Gas Optimizations**
    - [ ] Is the logic as simple as possible?
    - [ ] Are the storage values that are used repeatedly cached in stack or
          memory variables?
    - [ ] If loops are used, are there guards in place to avoid out-of-gas
          issues?
- [ ] **Visibility**
    - [ ] Are all `payable` functions restricted to avoid stuck ether?
- [ ] **Math**
    - [ ] Is all of the arithmetic checked or guarded by if-statements that will
          catch underflows?
    - [ ] If `Safe` functions are altered, are potential underflows and
          overflows caught so that a failure flag can be thrown?
    - [ ] Are all of the rounding directions clearly documented?
- [ ] **Testing**
    - [ ] Are there new or updated unit or integration tests?
    - [ ] Do the tests cover the happy paths?
    - [ ] Do the tests cover the unhappy paths?
    - [ ] Are there an adequate number of fuzz tests to ensure that we are
          covering the full input space?
