### PR TITLE
Updated the instance tests to support fuzzing of new integrations

### DIFF
--- a/test/instances/aave/AaveHyperdrive.t.sol
+++ b/test/instances/aave/AaveHyperdrive.t.sol
@@ -48,27 +48,27 @@ contract AaveHyperdriveTest is InstanceTest {
     address[] internal baseTokenWhaleAccounts = [WETH_WHALE];
     address[] internal vaultSharesTokenWhaleAccounts = [AWETH_WHALE];
 
-    // The configuration for the instance testing suite.
-    InstanceTestConfig internal __testConfig =
-        InstanceTestConfig({
-            name: "Hyperdrive",
-            kind: "AaveHyperdrive",
-            baseTokenWhaleAccounts: baseTokenWhaleAccounts,
-            vaultSharesTokenWhaleAccounts: vaultSharesTokenWhaleAccounts,
-            baseToken: WETH,
-            vaultSharesToken: IERC20(address(AWETH)),
-            shareTolerance: 1e3,
-            minTransactionAmount: 1e15,
-            positionDuration: POSITION_DURATION,
-            enableBaseDeposits: true,
-            enableShareDeposits: true,
-            enableBaseWithdraws: true,
-            enableShareWithdraws: true,
-            baseWithdrawError: new bytes(0)
-        });
-
     /// @dev Instantiates the instance testing suite with the configuration.
-    constructor() InstanceTest(__testConfig) {}
+    constructor()
+        InstanceTest(
+            InstanceTestConfig({
+                name: "Hyperdrive",
+                kind: "AaveHyperdrive",
+                baseTokenWhaleAccounts: baseTokenWhaleAccounts,
+                vaultSharesTokenWhaleAccounts: vaultSharesTokenWhaleAccounts,
+                baseToken: WETH,
+                vaultSharesToken: IERC20(address(AWETH)),
+                shareTolerance: 1e3,
+                minTransactionAmount: 1e15,
+                positionDuration: POSITION_DURATION,
+                enableBaseDeposits: true,
+                enableShareDeposits: true,
+                enableBaseWithdraws: true,
+                enableShareWithdraws: true,
+                baseWithdrawError: new bytes(0)
+            })
+        )
+    {}
 
     /// @dev Forge function that is invoked to setup the testing environment.
     function setUp() public override __mainnet_fork(20_276_503) {
@@ -80,14 +80,14 @@ contract AaveHyperdriveTest is InstanceTest {
 
     /// @dev Gets the extra data used to deploy Hyperdrive instances.
     /// @return The extra data.
-    function getExtraData() internal pure override returns (bytes memory) {
+    function getExtraData() public pure override returns (bytes memory) {
         return new bytes(0);
     }
 
     /// @dev Converts base amount to the equivalent about in shares.
     function convertToShares(
         uint256 baseAmount
-    ) internal view override returns (uint256) {
+    ) public view override returns (uint256) {
         return
             baseAmount.mulDivDown(
                 1e27,
@@ -98,7 +98,7 @@ contract AaveHyperdriveTest is InstanceTest {
     /// @dev Converts share amount to the equivalent amount in base.
     function convertToBase(
         uint256 shareAmount
-    ) internal view override returns (uint256) {
+    ) public view override returns (uint256) {
         return
             shareAmount.mulDivDown(
                 POOL.getReserveNormalizedIncome(address(WETH)),
@@ -110,12 +110,12 @@ contract AaveHyperdriveTest is InstanceTest {
     /// @param _factory The address of the Hyperdrive factory.
     function deployCoordinator(
         address _factory
-    ) internal override returns (address) {
+    ) public override returns (address) {
         vm.startPrank(alice);
         return
             address(
                 new AaveHyperdriveDeployerCoordinator(
-                    string.concat(__testConfig.name, "DeployerCoordinator"),
+                    string.concat(config.name, "DeployerCoordinator"),
                     _factory,
                     address(new AaveHyperdriveCoreDeployer()),
                     address(new AaveTarget0Deployer()),
@@ -128,14 +128,14 @@ contract AaveHyperdriveTest is InstanceTest {
     }
 
     /// @dev Fetches the total supply of the base and share tokens.
-    function getSupply() internal view override returns (uint256, uint256) {
+    function getSupply() public view override returns (uint256, uint256) {
         return (AWETH.totalSupply(), AWETH.scaledTotalSupply());
     }
 
     /// @dev Fetches the token balance information of an account.
     function getTokenBalances(
         address account
-    ) internal view override returns (uint256, uint256) {
+    ) public view override returns (uint256, uint256) {
         return (
             WETH.balanceOf(account),
             convertToShares(AWETH.balanceOf(account))
@@ -461,7 +461,7 @@ contract AaveHyperdriveTest is InstanceTest {
     function advanceTime(
         uint256 timeDelta,
         int256 variableRate
-    ) internal override {
+    ) public override {
         // Advance the time.
         vm.warp(block.timestamp + timeDelta);
 

--- a/test/instances/ezETH/EzETHHyperdrive.t.sol
+++ b/test/instances/ezETH/EzETHHyperdrive.t.sol
@@ -58,27 +58,27 @@ contract EzETHHyperdriveTest is InstanceTest {
     address internal EZETH_WHALE = 0x40C0d1fbcB0A43A62ca7A241E7A42ca58EeF96eb;
     address[] internal whaleAccounts = [EZETH_WHALE];
 
-    // The configuration for the instance testing suite.
-    InstanceTestConfig internal __testConfig =
-        InstanceTestConfig(
-            "Hyperdrive",
-            "EzETHHyperdrive",
-            new address[](0),
-            whaleAccounts,
-            IERC20(ETH),
-            IERC20(EZETH),
-            1e6,
-            1e15,
-            POSITION_DURATION_15_DAYS,
-            false,
-            true,
-            false,
-            true,
-            abi.encodeWithSelector(IHyperdrive.UnsupportedToken.selector)
-        );
-
     /// @dev Instantiates the instance testing suite with the configuration.
-    constructor() InstanceTest(__testConfig) {}
+    constructor()
+        InstanceTest(
+            InstanceTestConfig(
+                "Hyperdrive",
+                "EzETHHyperdrive",
+                new address[](0),
+                whaleAccounts,
+                IERC20(ETH),
+                IERC20(EZETH),
+                1e6,
+                1e15,
+                POSITION_DURATION_15_DAYS,
+                false,
+                true,
+                false,
+                true,
+                abi.encodeWithSelector(IHyperdrive.UnsupportedToken.selector)
+            )
+        )
+    {}
 
     /// @dev Forge function that is invoked to setup the testing environment.
     function setUp() public override __mainnet_fork(STARTING_BLOCK) {
@@ -96,14 +96,14 @@ contract EzETHHyperdriveTest is InstanceTest {
 
     /// @dev Gets the extra data used to deploy Hyperdrive instances.
     /// @return The extra data.
-    function getExtraData() internal pure override returns (bytes memory) {
+    function getExtraData() public pure override returns (bytes memory) {
         return new bytes(0);
     }
 
     /// @dev Converts base amount to the equivalent about in EzETH.
     function convertToShares(
         uint256 baseAmount
-    ) internal view override returns (uint256) {
+    ) public view override returns (uint256) {
         // Get protocol state information used for calculating shares.
         (uint256 sharePrice, , ) = getSharePrice();
         return baseAmount.divDown(sharePrice);
@@ -112,7 +112,7 @@ contract EzETHHyperdriveTest is InstanceTest {
     /// @dev Converts share amount to the equivalent amount in ETH.
     function convertToBase(
         uint256 baseAmount
-    ) internal view override returns (uint256) {
+    ) public view override returns (uint256) {
         // Get the total TVL priced in ETH from RestakeManager.
         (, , uint256 totalTVL) = RESTAKE_MANAGER.calculateTVLs();
 
@@ -131,12 +131,12 @@ contract EzETHHyperdriveTest is InstanceTest {
     /// @param _factory The address of the Hyperdrive factory contract.
     function deployCoordinator(
         address _factory
-    ) internal override returns (address) {
+    ) public override returns (address) {
         vm.startPrank(alice);
         return
             address(
                 new EzETHHyperdriveDeployerCoordinator(
-                    string.concat(__testConfig.name, "DeployerCoordinator"),
+                    string.concat(config.name, "DeployerCoordinator"),
                     _factory,
                     address(new EzETHHyperdriveCoreDeployer(RESTAKE_MANAGER)),
                     address(new EzETHTarget0Deployer(RESTAKE_MANAGER)),
@@ -152,13 +152,13 @@ contract EzETHHyperdriveTest is InstanceTest {
     /// @dev Fetches the token balance information of an account.
     function getTokenBalances(
         address account
-    ) internal view override returns (uint256, uint256) {
+    ) public view override returns (uint256, uint256) {
         // EzETH does not have a convenient function for fetching base balance.
         return (0, EZETH.balanceOf(account));
     }
 
     /// @dev Fetches the total supply of the base and share tokens.
-    function getSupply() internal view override returns (uint256, uint256) {
+    function getSupply() public view override returns (uint256, uint256) {
         (, uint256 totalPooledEther, ) = getSharePrice();
         return (totalPooledEther, EZETH.totalSupply());
     }
@@ -563,7 +563,7 @@ contract EzETHHyperdriveTest is InstanceTest {
     function advanceTime(
         uint256 timeDelta, // assume a position duration jump
         int256 variableRate // annual variable rate
-    ) internal override {
+    ) public override {
         // Advance the time by a position duration and accrue interest.  We
         // adjust the variable rate to the position duration and multiply the
         // TVL to get interest:

--- a/test/instances/lseth/LsETHHyperdrive.t.sol
+++ b/test/instances/lseth/LsETHHyperdrive.t.sol
@@ -45,27 +45,27 @@ contract LsETHHyperdriveTest is InstanceTest {
         LSETH_WHALE_3
     ];
 
-    // The configuration for the instance testing suite.
-    InstanceTestConfig internal __testConfig =
-        InstanceTestConfig(
-            "Hyperdrive",
-            "LsETHHyperdrive",
-            new address[](0),
-            whaleAccounts,
-            IERC20(ETH),
-            IERC20(RIVER),
-            1e5,
-            1e15,
-            POSITION_DURATION,
-            false,
-            true,
-            false,
-            true,
-            abi.encodeWithSelector(IHyperdrive.UnsupportedToken.selector)
-        );
-
     /// @dev Instantiates the instance testing suite with the configuration.
-    constructor() InstanceTest(__testConfig) {}
+    constructor()
+        InstanceTest(
+            InstanceTestConfig(
+                "Hyperdrive",
+                "LsETHHyperdrive",
+                new address[](0),
+                whaleAccounts,
+                IERC20(ETH),
+                IERC20(RIVER),
+                1e5,
+                1e15,
+                POSITION_DURATION,
+                false,
+                true,
+                false,
+                true,
+                abi.encodeWithSelector(IHyperdrive.UnsupportedToken.selector)
+            )
+        )
+    {}
 
     /// @dev Forge function that is invoked to setup the testing environment.
 
@@ -78,7 +78,7 @@ contract LsETHHyperdriveTest is InstanceTest {
 
     /// @dev Gets the extra data used to deploy Hyperdrive instances.
     /// @return The extra data.
-    function getExtraData() internal pure override returns (bytes memory) {
+    function getExtraData() public pure override returns (bytes memory) {
         return new bytes(0);
     }
 
@@ -86,12 +86,12 @@ contract LsETHHyperdriveTest is InstanceTest {
     /// @param _factory The address of the Hyperdrive factory contract.
     function deployCoordinator(
         address _factory
-    ) internal override returns (address) {
+    ) public override returns (address) {
         vm.startPrank(alice);
         return
             address(
                 new LsETHHyperdriveDeployerCoordinator(
-                    string.concat(__testConfig.name, "DeployerCoordinator"),
+                    string.concat(config.name, "DeployerCoordinator"),
                     _factory,
                     address(new LsETHHyperdriveCoreDeployer()),
                     address(new LsETHTarget0Deployer()),
@@ -107,7 +107,7 @@ contract LsETHHyperdriveTest is InstanceTest {
     /// @dev Converts base amount to the equivalent amount in LsETH.
     function convertToShares(
         uint256 baseAmount
-    ) internal view override returns (uint256) {
+    ) public view override returns (uint256) {
         // River has a built-in function for computing price in terms of shares.
         return RIVER.sharesFromUnderlyingBalance(baseAmount);
     }
@@ -115,7 +115,7 @@ contract LsETHHyperdriveTest is InstanceTest {
     /// @dev Converts base amount to the equivalent amount in ETH.
     function convertToBase(
         uint256 shareAmount
-    ) internal view override returns (uint256) {
+    ) public view override returns (uint256) {
         // River has a built-in function for computing price in terms of base.
         return RIVER.underlyingBalanceFromShares(shareAmount);
     }
@@ -123,12 +123,12 @@ contract LsETHHyperdriveTest is InstanceTest {
     /// @dev Fetches the token balance information of an account.
     function getTokenBalances(
         address account
-    ) internal view override returns (uint256, uint256) {
+    ) public view override returns (uint256, uint256) {
         return (RIVER.balanceOfUnderlying(account), RIVER.balanceOf(account));
     }
 
     /// @dev Fetches the total supply of the base and share tokens.
-    function getSupply() internal view override returns (uint256, uint256) {
+    function getSupply() public view override returns (uint256, uint256) {
         return (RIVER.totalUnderlyingSupply(), RIVER.totalSupply());
     }
 
@@ -328,7 +328,7 @@ contract LsETHHyperdriveTest is InstanceTest {
     function advanceTime(
         uint256 timeDelta,
         int256 variableRate
-    ) internal override {
+    ) public override {
         // Storage slot for LsETH underlying ether balance.
         bytes32 lastConsensusLayerReportSlot = bytes32(
             uint256(keccak256("river.state.lastConsensusLayerReport"))

--- a/test/instances/morpho-blue/MorphoBlueHyperdrive.t.sol
+++ b/test/instances/morpho-blue/MorphoBlueHyperdrive.t.sol
@@ -69,35 +69,35 @@ contract MorphoBlueHyperdriveTest is InstanceTest {
         address(0xBBBBBbbBBb9cC5e90e3b3Af64bdAF62C37EEFFCb);
     address[] internal baseTokenWhaleAccounts = [LOAN_TOKEN_WHALE];
 
-    // The configuration for the instance testing suite.
-    InstanceTestConfig internal __testConfig =
-        InstanceTestConfig({
-            name: "Hyperdrive",
-            kind: "MorphoBlueHyperdrive",
-            baseTokenWhaleAccounts: baseTokenWhaleAccounts,
-            vaultSharesTokenWhaleAccounts: new address[](0),
-            baseToken: IERC20(LOAN_TOKEN),
-            vaultSharesToken: IERC20(address(0)),
-            // NOTE: The share tolerance is quite high for this integration
-            // because the vault share price is ~1e12, which means that just
-            // multiplying or dividing by the vault is an imprecise way of
-            // converting between base and vault shares. We included more
-            // assertions than normal to the round trip tests to verify that
-            // the calculations satisfy our expectations of accuracy.
-            shareTolerance: 1e15,
-            minTransactionAmount: 1e15,
-            positionDuration: POSITION_DURATION,
-            enableBaseDeposits: true,
-            enableShareDeposits: false,
-            enableBaseWithdraws: true,
-            enableShareWithdraws: false,
-            baseWithdrawError: abi.encodeWithSelector(
-                IHyperdrive.UnsupportedToken.selector
-            )
-        });
-
     /// @dev Instantiates the instance testing suite with the configuration.
-    constructor() InstanceTest(__testConfig) {}
+    constructor()
+        InstanceTest(
+            InstanceTestConfig({
+                name: "Hyperdrive",
+                kind: "MorphoBlueHyperdrive",
+                baseTokenWhaleAccounts: baseTokenWhaleAccounts,
+                vaultSharesTokenWhaleAccounts: new address[](0),
+                baseToken: IERC20(LOAN_TOKEN),
+                vaultSharesToken: IERC20(address(0)),
+                // NOTE: The share tolerance is quite high for this integration
+                // because the vault share price is ~1e12, which means that just
+                // multiplying or dividing by the vault is an imprecise way of
+                // converting between base and vault shares. We included more
+                // assertions than normal to the round trip tests to verify that
+                // the calculations satisfy our expectations of accuracy.
+                shareTolerance: 1e15,
+                minTransactionAmount: 1e15,
+                positionDuration: POSITION_DURATION,
+                enableBaseDeposits: true,
+                enableShareDeposits: false,
+                enableBaseWithdraws: true,
+                enableShareWithdraws: false,
+                baseWithdrawError: abi.encodeWithSelector(
+                    IHyperdrive.UnsupportedToken.selector
+                )
+            })
+        )
+    {}
 
     /// @dev Forge function that is invoked to setup the testing environment.
     function setUp() public override __mainnet_fork(20_276_503) {
@@ -109,7 +109,7 @@ contract MorphoBlueHyperdriveTest is InstanceTest {
 
     /// @dev Gets the extra data used to deploy Hyperdrive instances.
     /// @return The extra data.
-    function getExtraData() internal pure override returns (bytes memory) {
+    function getExtraData() public pure override returns (bytes memory) {
         return
             abi.encode(
                 IMorphoBlueHyperdrive.MorphoBlueParams({
@@ -125,7 +125,7 @@ contract MorphoBlueHyperdriveTest is InstanceTest {
     /// @dev Converts base amount to the equivalent about in shares.
     function convertToShares(
         uint256 baseAmount
-    ) internal view override returns (uint256) {
+    ) public view override returns (uint256) {
         return
             MorphoBlueConversions.convertToShares(
                 MORPHO,
@@ -141,7 +141,7 @@ contract MorphoBlueHyperdriveTest is InstanceTest {
     /// @dev Converts share amount to the equivalent amount in base.
     function convertToBase(
         uint256 shareAmount
-    ) internal view override returns (uint256) {
+    ) public view override returns (uint256) {
         return
             MorphoBlueConversions.convertToBase(
                 MORPHO,
@@ -158,12 +158,12 @@ contract MorphoBlueHyperdriveTest is InstanceTest {
     /// @param _factory The address of the Hyperdrive factory.
     function deployCoordinator(
         address _factory
-    ) internal override returns (address) {
+    ) public override returns (address) {
         vm.startPrank(alice);
         return
             address(
                 new MorphoBlueHyperdriveDeployerCoordinator(
-                    string.concat(__testConfig.name, "DeployerCoordinator"),
+                    string.concat(config.name, "DeployerCoordinator"),
                     _factory,
                     address(new MorphoBlueHyperdriveCoreDeployer()),
                     address(new MorphoBlueTarget0Deployer()),
@@ -176,7 +176,7 @@ contract MorphoBlueHyperdriveTest is InstanceTest {
     }
 
     /// @dev Fetches the total supply of the base and share tokens.
-    function getSupply() internal view override returns (uint256, uint256) {
+    function getSupply() public view override returns (uint256, uint256) {
         (uint256 totalSupplyAssets, uint256 totalSupplyShares, , ) = MORPHO
             .expectedMarketBalances(
                 MarketParams({
@@ -193,7 +193,7 @@ contract MorphoBlueHyperdriveTest is InstanceTest {
     /// @dev Fetches the token balance information of an account.
     function getTokenBalances(
         address account
-    ) internal view override returns (uint256, uint256) {
+    ) public view override returns (uint256, uint256) {
         return (
             IERC20(LOAN_TOKEN).balanceOf(account),
             MORPHO
@@ -381,7 +381,7 @@ contract MorphoBlueHyperdriveTest is InstanceTest {
         assertApproxEqAbs(
             hyperdriveSharesAfter,
             hyperdriveSharesBefore + basePaid.divDown(vaultSharePrice),
-            __testConfig.shareTolerance
+            config.shareTolerance
         );
     }
 
@@ -729,7 +729,7 @@ contract MorphoBlueHyperdriveTest is InstanceTest {
     function advanceTime(
         uint256 timeDelta,
         int256 variableRate
-    ) internal override {
+    ) public override {
         // Advance the time.
         vm.warp(block.timestamp + timeDelta);
 

--- a/test/instances/reth/RETHHyperdrive.t.sol
+++ b/test/instances/reth/RETHHyperdrive.t.sol
@@ -49,27 +49,27 @@ contract RETHHyperdriveTest is InstanceTest {
     address internal RETH_WHALE = 0xCc9EE9483f662091a1de4795249E24aC0aC2630f;
     address[] internal whaleAccounts = [RETH_WHALE];
 
-    // The configuration for the Instance testing suite.
-    InstanceTestConfig internal __testConfig =
-        InstanceTestConfig(
-            "Hyperdrive",
-            "RETHHyperdrive",
-            new address[](0),
-            whaleAccounts,
-            IERC20(ETH),
-            IERC20(rocketTokenRETH),
-            1e5,
-            1e15,
-            POSITION_DURATION,
-            false,
-            true,
-            true,
-            true,
-            new bytes(0)
-        );
-
     /// @dev Instantiates the instance testing suite with the configuration.
-    constructor() InstanceTest(__testConfig) {}
+    constructor()
+        InstanceTest(
+            InstanceTestConfig(
+                "Hyperdrive",
+                "RETHHyperdrive",
+                new address[](0),
+                whaleAccounts,
+                IERC20(ETH),
+                IERC20(rocketTokenRETH),
+                1e5,
+                1e15,
+                POSITION_DURATION,
+                false,
+                true,
+                true,
+                true,
+                new bytes(0)
+            )
+        )
+    {}
 
     /// @dev Forge function that is invoked to setup the testing environment.
     function setUp() public override __mainnet_fork(19_429_100) {
@@ -84,14 +84,14 @@ contract RETHHyperdriveTest is InstanceTest {
 
     /// @dev Gets the extra data used to deploy Hyperdrive instances.
     /// @return The extra data.
-    function getExtraData() internal pure override returns (bytes memory) {
+    function getExtraData() public pure override returns (bytes memory) {
         return new bytes(0);
     }
 
     /// @dev Converts base amount to the equivalent amount in rETH.
     function convertToShares(
         uint256 baseAmount
-    ) internal view override returns (uint256) {
+    ) public view override returns (uint256) {
         // Rocket Pool has a built-in function for computing price in terms of shares.
         return rocketTokenRETH.getRethValue(baseAmount);
     }
@@ -99,7 +99,7 @@ contract RETHHyperdriveTest is InstanceTest {
     /// @dev Converts share amount to the equivalent amount in ETH.
     function convertToBase(
         uint256 baseAmount
-    ) internal view override returns (uint256) {
+    ) public view override returns (uint256) {
         // Rocket Pool has a built-in function for computing price in terms of base.
         return rocketTokenRETH.getEthValue(baseAmount);
     }
@@ -107,12 +107,12 @@ contract RETHHyperdriveTest is InstanceTest {
     /// @dev Deploys the rETH deployer coordinator contract.
     function deployCoordinator(
         address _factory
-    ) internal override returns (address) {
+    ) public override returns (address) {
         vm.startPrank(alice);
         return
             address(
                 new RETHHyperdriveDeployerCoordinator(
-                    string.concat(__testConfig.name, "DeployerCoordinator"),
+                    string.concat(config.name, "DeployerCoordinator"),
                     _factory,
                     address(new RETHHyperdriveCoreDeployer()),
                     address(new RETHTarget0Deployer()),
@@ -126,7 +126,7 @@ contract RETHHyperdriveTest is InstanceTest {
     }
 
     /// @dev Fetches the total supply of the base and share tokens.
-    function getSupply() internal view override returns (uint256, uint256) {
+    function getSupply() public view override returns (uint256, uint256) {
         return (
             rocketNetworkBalances.getTotalETHBalance(),
             rocketNetworkBalances.getTotalRETHSupply()
@@ -136,7 +136,7 @@ contract RETHHyperdriveTest is InstanceTest {
     /// @dev Fetches the token balance information of an account.
     function getTokenBalances(
         address account
-    ) internal view override returns (uint256, uint256) {
+    ) public view override returns (uint256, uint256) {
         uint256 rethBalance = rocketTokenRETH.balanceOf(account);
         return (rocketTokenRETH.getEthValue(rethBalance), rethBalance);
     }
@@ -377,7 +377,7 @@ contract RETHHyperdriveTest is InstanceTest {
     function advanceTime(
         uint256 timeDelta,
         int256 variableRate
-    ) internal override {
+    ) public override {
         // Advance the time.
         vm.startPrank(address(rocketNetworkBalances));
         vm.warp(block.timestamp + timeDelta);

--- a/test/instances/steth/StETHHyperdrive.t.sol
+++ b/test/instances/steth/StETHHyperdrive.t.sol
@@ -40,27 +40,27 @@ contract StETHHyperdriveTest is InstanceTest {
     address internal STETH_WHALE = 0x1982b2F5814301d4e9a8b0201555376e62F82428;
     address[] internal whaleAccounts = [STETH_WHALE];
 
-    // The configuration for the instance testing suite.
-    InstanceTestConfig internal __testConfig =
-        InstanceTestConfig(
-            "Hyperdrive",
-            "StETHHyperdrive",
-            new address[](0),
-            whaleAccounts,
-            IERC20(ETH),
-            IERC20(LIDO),
-            1e5,
-            1e15,
-            POSITION_DURATION,
-            true,
-            true,
-            false,
-            true,
-            abi.encodeWithSelector(IHyperdrive.UnsupportedToken.selector)
-        );
-
     /// @dev Instantiates the instance testing suite with the configuration.
-    constructor() InstanceTest(__testConfig) {}
+    constructor()
+        InstanceTest(
+            InstanceTestConfig(
+                "Hyperdrive",
+                "StETHHyperdrive",
+                new address[](0),
+                whaleAccounts,
+                IERC20(ETH),
+                IERC20(LIDO),
+                1e5,
+                1e15,
+                POSITION_DURATION,
+                true,
+                true,
+                false,
+                true,
+                abi.encodeWithSelector(IHyperdrive.UnsupportedToken.selector)
+            )
+        )
+    {}
 
     /// @dev Forge function that is invoked to setup the testing environment.
     function setUp() public override __mainnet_fork(17_376_154) {
@@ -72,14 +72,14 @@ contract StETHHyperdriveTest is InstanceTest {
 
     /// @dev Gets the extra data used to deploy Hyperdrive instances.
     /// @return The extra data.
-    function getExtraData() internal pure override returns (bytes memory) {
+    function getExtraData() public pure override returns (bytes memory) {
         return new bytes(0);
     }
 
     /// @dev Converts base amount to the equivalent about in stETH.
     function convertToShares(
         uint256 baseAmount
-    ) internal view override returns (uint256) {
+    ) public view override returns (uint256) {
         // Get protocol state information used for calculating shares.
         uint256 totalPooledEther = LIDO.getTotalPooledEther();
         uint256 totalShares = LIDO.getTotalShares();
@@ -89,7 +89,7 @@ contract StETHHyperdriveTest is InstanceTest {
     /// @dev Converts share amount to the equivalent amount in ETH.
     function convertToBase(
         uint256 shareAmount
-    ) internal view override returns (uint256) {
+    ) public view override returns (uint256) {
         // Lido has a built-in function for computing price in terms of base.
         return LIDO.getPooledEthByShares(shareAmount);
     }
@@ -98,12 +98,12 @@ contract StETHHyperdriveTest is InstanceTest {
     /// @param _factory The address of the Hyperdrive factory.
     function deployCoordinator(
         address _factory
-    ) internal override returns (address) {
+    ) public override returns (address) {
         vm.startPrank(alice);
         return
             address(
                 new StETHHyperdriveDeployerCoordinator(
-                    string.concat(__testConfig.name, "DeployerCoordinator"),
+                    string.concat(config.name, "DeployerCoordinator"),
                     _factory,
                     address(new StETHHyperdriveCoreDeployer()),
                     address(new StETHTarget0Deployer()),
@@ -117,14 +117,14 @@ contract StETHHyperdriveTest is InstanceTest {
     }
 
     /// @dev Fetches the total supply of the base and share tokens.
-    function getSupply() internal view override returns (uint256, uint256) {
+    function getSupply() public view override returns (uint256, uint256) {
         return (LIDO.getTotalPooledEther(), LIDO.getTotalShares());
     }
 
     /// @dev Fetches the token balance information of an account.
     function getTokenBalances(
         address account
-    ) internal view override returns (uint256, uint256) {
+    ) public view override returns (uint256, uint256) {
         return (LIDO.balanceOf(account), LIDO.sharesOf(account));
     }
 
@@ -514,7 +514,7 @@ contract StETHHyperdriveTest is InstanceTest {
     function advanceTime(
         uint256 timeDelta,
         int256 variableRate
-    ) internal override {
+    ) public override {
         // Advance the time.
         vm.warp(block.timestamp + timeDelta);
 

--- a/test/instances/susde/SUSDe.t.sol
+++ b/test/instances/susde/SUSDe.t.sol
@@ -50,33 +50,33 @@ contract SUSDeHyperdriveTest is InstanceTest {
         address(0x4139cDC6345aFFbaC0692b43bed4D059Df3e6d65);
     address[] internal vaultSharesTokenWhaleAccounts = [SUSDE_TOKEN_WHALE];
 
-    // The configuration for the instance testing suite.
-    InstanceTestConfig internal __testConfig =
-        InstanceTestConfig({
-            name: "Hyperdrive",
-            kind: "ERC4626Hyperdrive",
-            baseTokenWhaleAccounts: baseTokenWhaleAccounts,
-            vaultSharesTokenWhaleAccounts: vaultSharesTokenWhaleAccounts,
-            baseToken: USDE,
-            vaultSharesToken: IERC20(address(SUSDE)),
-            shareTolerance: 1e3,
-            minTransactionAmount: 1e15,
-            positionDuration: POSITION_DURATION,
-            enableBaseDeposits: true,
-            enableShareDeposits: true,
-            enableBaseWithdraws: false,
-            enableShareWithdraws: true,
-            // NOTE: SUSDe currently has a cooldown on withdrawals which
-            // prevents users from withdrawing as base instantaneously. We still
-            // support withdrawing with base since the cooldown can be disabled
-            // in the future.
-            baseWithdrawError: abi.encodeWithSelector(
-                OperationNotAllowed.selector
-            )
-        });
-
     /// @dev Instantiates the instance testing suite with the configuration.
-    constructor() InstanceTest(__testConfig) {}
+    constructor()
+        InstanceTest(
+            InstanceTestConfig({
+                name: "Hyperdrive",
+                kind: "ERC4626Hyperdrive",
+                baseTokenWhaleAccounts: baseTokenWhaleAccounts,
+                vaultSharesTokenWhaleAccounts: vaultSharesTokenWhaleAccounts,
+                baseToken: USDE,
+                vaultSharesToken: IERC20(address(SUSDE)),
+                shareTolerance: 1e3,
+                minTransactionAmount: 1e15,
+                positionDuration: POSITION_DURATION,
+                enableBaseDeposits: true,
+                enableShareDeposits: true,
+                enableBaseWithdraws: false,
+                enableShareWithdraws: true,
+                // NOTE: SUSDe currently has a cooldown on withdrawals which
+                // prevents users from withdrawing as base instantaneously. We still
+                // support withdrawing with base since the cooldown can be disabled
+                // in the future.
+                baseWithdrawError: abi.encodeWithSelector(
+                    OperationNotAllowed.selector
+                )
+            })
+        )
+    {}
 
     /// @dev Forge function that is invoked to setup the testing environment.
     function setUp() public override __mainnet_fork(20_335_384) {
@@ -88,14 +88,14 @@ contract SUSDeHyperdriveTest is InstanceTest {
 
     /// @dev Gets the extra data used to deploy Hyperdrive instances.
     /// @return The extra data.
-    function getExtraData() internal pure override returns (bytes memory) {
+    function getExtraData() public pure override returns (bytes memory) {
         return new bytes(0);
     }
 
     /// @dev Converts base amount to the equivalent about in shares.
     function convertToShares(
         uint256 baseAmount
-    ) internal view override returns (uint256) {
+    ) public view override returns (uint256) {
         return
             ERC4626Conversions.convertToShares(
                 IERC20(address(SUSDE)),
@@ -106,7 +106,7 @@ contract SUSDeHyperdriveTest is InstanceTest {
     /// @dev Converts share amount to the equivalent amount in base.
     function convertToBase(
         uint256 shareAmount
-    ) internal view override returns (uint256) {
+    ) public view override returns (uint256) {
         return
             ERC4626Conversions.convertToBase(
                 IERC20(address(SUSDE)),
@@ -118,12 +118,12 @@ contract SUSDeHyperdriveTest is InstanceTest {
     /// @param _factory The address of the Hyperdrive factory.
     function deployCoordinator(
         address _factory
-    ) internal override returns (address) {
+    ) public override returns (address) {
         vm.startPrank(alice);
         return
             address(
                 new ERC4626HyperdriveDeployerCoordinator(
-                    string.concat(__testConfig.name, "DeployerCoordinator"),
+                    string.concat(config.name, "DeployerCoordinator"),
                     _factory,
                     address(new ERC4626HyperdriveCoreDeployer()),
                     address(new ERC4626Target0Deployer()),
@@ -136,14 +136,14 @@ contract SUSDeHyperdriveTest is InstanceTest {
     }
 
     /// @dev Fetches the total supply of the base and share tokens.
-    function getSupply() internal view override returns (uint256, uint256) {
+    function getSupply() public view override returns (uint256, uint256) {
         return (SUSDE.totalAssets(), SUSDE.totalSupply());
     }
 
     /// @dev Fetches the token balance information of an account.
     function getTokenBalances(
         address account
-    ) internal view override returns (uint256, uint256) {
+    ) public view override returns (uint256, uint256) {
         return (USDE.balanceOf(account), SUSDE.balanceOf(account));
     }
 
@@ -367,7 +367,7 @@ contract SUSDeHyperdriveTest is InstanceTest {
         assertApproxEqAbs(
             hyperdriveSharesAfter,
             hyperdriveSharesBefore + basePaid.divDown(vaultSharePrice),
-            __testConfig.shareTolerance
+            config.shareTolerance
         );
     }
 
@@ -739,7 +739,7 @@ contract SUSDeHyperdriveTest is InstanceTest {
     function advanceTime(
         uint256 timeDelta,
         int256 variableRate
-    ) internal override {
+    ) public override {
         // Get the total base before advancing the time. This is important
         // because it ensures that we are accruing interest on the current
         // amount of total assets rather than the amount of total assets after

--- a/test/utils/BaseTest.sol
+++ b/test/utils/BaseTest.sol
@@ -27,9 +27,6 @@ contract BaseTest is Test {
 
     uint256 __init__; // time setup function was ran
 
-    string MAINNET_RPC_URL = vm.envString("MAINNET_RPC_URL");
-    string SEPOLIA_RPC_URL = vm.envString("SEPOLIA_RPC_URL");
-
     bool isForked;
 
     function setUp() public virtual {
@@ -52,7 +49,7 @@ contract BaseTest is Test {
     }
 
     modifier __mainnet_fork(uint256 blockNumber) {
-        uint256 mainnetForkId = vm.createFork(MAINNET_RPC_URL);
+        uint256 mainnetForkId = vm.createFork(vm.envString("MAINNET_RPC_URL"));
         vm.selectFork(mainnetForkId);
         vm.rollFork(blockNumber);
         isForked = true;
@@ -61,7 +58,7 @@ contract BaseTest is Test {
     }
 
     modifier __sepolia_fork(uint256 blockNumber) {
-        uint256 sepoliaForkId = vm.createFork(SEPOLIA_RPC_URL);
+        uint256 sepoliaForkId = vm.createFork(vm.envString("SEPOLIA_RPC_URL"));
         vm.selectFork(sepoliaForkId);
         vm.rollFork(blockNumber);
         isForked = true;

--- a/test/utils/HyperdriveTest.sol
+++ b/test/utils/HyperdriveTest.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.20;
 
-import { console2 as console } from "forge-std/console2.sol";
-
 import { VmSafe } from "forge-std/Vm.sol";
 import { HyperdriveFactory } from "contracts/src/factory/HyperdriveFactory.sol";
 import { IERC20 } from "contracts/src/interfaces/IERC20.sol";

--- a/test/utils/HyperdriveTest.sol
+++ b/test/utils/HyperdriveTest.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.20;
 
+import { console2 as console } from "forge-std/console2.sol";
+
 import { VmSafe } from "forge-std/Vm.sol";
 import { HyperdriveFactory } from "contracts/src/factory/HyperdriveFactory.sol";
 import { IERC20 } from "contracts/src/interfaces/IERC20.sol";
@@ -825,7 +827,7 @@ contract HyperdriveTest is IHyperdriveEvents, BaseTest {
 
     /// Utils ///
 
-    function advanceTime(uint256 time, int256 variableRate) internal virtual {
+    function advanceTime(uint256 time, int256 variableRate) public virtual {
         MockHyperdrive(address(hyperdrive)).accrue(time, variableRate);
         vm.warp(block.timestamp + time);
     }


### PR DESCRIPTION
# Resolved Issues

Partially resolves: #1108.

# Description

This PR makes several functions in the `InstanceTest` harness public. This makes it possible to leverage this functionality on a mainnet fork to run fuzz tests against new integrations. This is the PR that should bring this system to the MCP (minimum crappy product). Some notable features that are absent are:

- The ability to fund arbitrary accounts. For now, these integrations will rely upon whale addresses, which also means that the fork block is important. 
- Advance time will increase the time internally as well as accrue interest. This PR doesn't add a separate `accrue` function, although that will not be hard to add in a later PR.