### PR TITLE
Added a rule to the style guide about leading underscores in parameters

### DIFF
--- a/STYLE_GUIDE.md
+++ b/STYLE_GUIDE.md
@@ -45,3 +45,7 @@
 1. Each immutable should have a corresponding getter.
 2. Each state variable should have a corresponding getter or should be reachable through a generalized getter (like `loads`).
 3. Each function that changes state should have an event that encodes the state changes that occurred within the function call. If possible, this event should be sufficient to fully recreate the state change that occurred from the previous state.
+
+# Functions
+
+1. Parameters should be prefaced with a leading underscore (`_`). To avoid shadowing internal or private immutable or storage values, prefix the parameter with a double underscore (`__`).

--- a/contracts/src/deployers/eeth/EETHHyperdriveDeployerCoordinator.sol
+++ b/contracts/src/deployers/eeth/EETHHyperdriveDeployerCoordinator.sol
@@ -2,11 +2,8 @@
 pragma solidity 0.8.20;
 
 import { IERC20 } from "../../interfaces/IERC20.sol";
-import { ERC20 } from "openzeppelin/token/ERC20/ERC20.sol";
-import { SafeERC20 } from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 import { IEETH } from "../../interfaces/IEETH.sol";
 import { IHyperdrive } from "../../interfaces/IHyperdrive.sol";
-import { IEETHHyperdrive } from "../../interfaces/IEETHHyperdrive.sol";
 import { IHyperdriveDeployerCoordinator } from "../../interfaces/IHyperdriveDeployerCoordinator.sol";
 import { EETH_HYPERDRIVE_DEPLOYER_COORDINATOR_KIND } from "../../libraries/Constants.sol";
 import { ONE } from "../../libraries/FixedPointMath.sol";

--- a/contracts/src/deployers/eeth/EETHTarget0Deployer.sol
+++ b/contracts/src/deployers/eeth/EETHTarget0Deployer.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.20;
 
 import { EETHTarget0 } from "../../instances/eeth/EETHTarget0.sol";
-import { IEETH } from "../../interfaces/IEETH.sol";
 import { IHyperdrive } from "../../interfaces/IHyperdrive.sol";
 import { IHyperdriveTargetDeployer } from "../../interfaces/IHyperdriveTargetDeployer.sol";
 import { ILiquidityPool } from "../../interfaces/ILiquidityPool.sol";

--- a/contracts/src/deployers/eeth/EETHTarget1Deployer.sol
+++ b/contracts/src/deployers/eeth/EETHTarget1Deployer.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.20;
 
 import { EETHTarget1 } from "../../instances/eeth/EETHTarget1.sol";
-import { IEETH } from "../../interfaces/IEETH.sol";
 import { IHyperdrive } from "../../interfaces/IHyperdrive.sol";
 import { IHyperdriveTargetDeployer } from "../../interfaces/IHyperdriveTargetDeployer.sol";
 import { ILiquidityPool } from "../../interfaces/ILiquidityPool.sol";

--- a/contracts/src/deployers/eeth/EETHTarget2Deployer.sol
+++ b/contracts/src/deployers/eeth/EETHTarget2Deployer.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.20;
 
 import { EETHTarget2 } from "../../instances/eeth/EETHTarget2.sol";
-import { IEETH } from "../../interfaces/IEETH.sol";
 import { IHyperdrive } from "../../interfaces/IHyperdrive.sol";
 import { IHyperdriveTargetDeployer } from "../../interfaces/IHyperdriveTargetDeployer.sol";
 import { ILiquidityPool } from "../../interfaces/ILiquidityPool.sol";

--- a/contracts/src/deployers/eeth/EETHTarget3Deployer.sol
+++ b/contracts/src/deployers/eeth/EETHTarget3Deployer.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.20;
 
 import { EETHTarget3 } from "../../instances/eeth/EETHTarget3.sol";
-import { IEETH } from "../../interfaces/IEETH.sol";
 import { IHyperdrive } from "../../interfaces/IHyperdrive.sol";
 import { IHyperdriveTargetDeployer } from "../../interfaces/IHyperdriveTargetDeployer.sol";
 import { ILiquidityPool } from "../../interfaces/ILiquidityPool.sol";

--- a/contracts/src/deployers/eeth/EETHTarget4Deployer.sol
+++ b/contracts/src/deployers/eeth/EETHTarget4Deployer.sol
@@ -2,7 +2,6 @@
 pragma solidity 0.8.20;
 
 import { EETHTarget4 } from "../../instances/eeth/EETHTarget4.sol";
-import { IEETH } from "../../interfaces/IEETH.sol";
 import { IHyperdrive } from "../../interfaces/IHyperdrive.sol";
 import { IHyperdriveTargetDeployer } from "../../interfaces/IHyperdriveTargetDeployer.sol";
 import { ILiquidityPool } from "../../interfaces/ILiquidityPool.sol";

--- a/contracts/src/instances/eeth/EETHConversions.sol
+++ b/contracts/src/instances/eeth/EETHConversions.sol
@@ -3,7 +3,7 @@ pragma solidity 0.8.20;
 
 import { IERC20 } from "../../interfaces/IERC20.sol";
 import { ILiquidityPool } from "../../interfaces/ILiquidityPool.sol";
-import { FixedPointMath, ONE } from "../../libraries/FixedPointMath.sol";
+import { FixedPointMath } from "../../libraries/FixedPointMath.sol";
 import { IEETH } from "../../interfaces/IEETH.sol";
 
 /// @author DELV

--- a/contracts/src/instances/eeth/EETHHyperdrive.sol
+++ b/contracts/src/instances/eeth/EETHHyperdrive.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.20;
 
-import { IERC20 } from "../../interfaces/IERC20.sol";
 import { IHyperdrive } from "../../interfaces/IHyperdrive.sol";
 import { ILiquidityPool } from "../../interfaces/ILiquidityPool.sol";
 import { Hyperdrive } from "../../external/Hyperdrive.sol";

--- a/contracts/src/instances/lseth/LsETHBase.sol
+++ b/contracts/src/instances/lseth/LsETHBase.sol
@@ -4,7 +4,6 @@ pragma solidity 0.8.20;
 import { ERC20 } from "openzeppelin/token/ERC20/ERC20.sol";
 import { SafeERC20 } from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 import { IHyperdrive } from "../../interfaces/IHyperdrive.sol";
-import { IRiverV1 } from "../../interfaces/IRiverV1.sol";
 import { HyperdriveBase } from "../../internal/HyperdriveBase.sol";
 import { LsETHConversions } from "./LsETHConversions.sol";
 

--- a/contracts/src/instances/morpho-blue/MorphoBlueHyperdrive.sol
+++ b/contracts/src/instances/morpho-blue/MorphoBlueHyperdrive.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.20;
 
-import { IMorpho } from "morpho-blue/src/interfaces/IMorpho.sol";
 import { ERC20 } from "openzeppelin/token/ERC20/ERC20.sol";
 import { SafeERC20 } from "openzeppelin/token/ERC20/utils/SafeERC20.sol";
 import { Hyperdrive } from "../../external/Hyperdrive.sol";

--- a/contracts/src/instances/morpho-blue/MorphoBlueTarget1.sol
+++ b/contracts/src/instances/morpho-blue/MorphoBlueTarget1.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.20;
 
-import { IMorpho } from "morpho-blue/src/interfaces/IMorpho.sol";
 import { HyperdriveTarget1 } from "../../external/HyperdriveTarget1.sol";
 import { IHyperdrive } from "../../interfaces/IHyperdrive.sol";
 import { IMorphoBlueHyperdrive } from "../../interfaces/IMorphoBlueHyperdrive.sol";

--- a/contracts/src/instances/morpho-blue/MorphoBlueTarget2.sol
+++ b/contracts/src/instances/morpho-blue/MorphoBlueTarget2.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.20;
 
-import { IMorpho } from "morpho-blue/src/interfaces/IMorpho.sol";
 import { HyperdriveTarget2 } from "../../external/HyperdriveTarget2.sol";
 import { IHyperdrive } from "../../interfaces/IHyperdrive.sol";
 import { IMorphoBlueHyperdrive } from "../../interfaces/IMorphoBlueHyperdrive.sol";

--- a/contracts/src/instances/morpho-blue/MorphoBlueTarget3.sol
+++ b/contracts/src/instances/morpho-blue/MorphoBlueTarget3.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.20;
 
-import { IMorpho } from "morpho-blue/src/interfaces/IMorpho.sol";
 import { HyperdriveTarget3 } from "../../external/HyperdriveTarget3.sol";
 import { IHyperdrive } from "../../interfaces/IHyperdrive.sol";
 import { IMorphoBlueHyperdrive } from "../../interfaces/IMorphoBlueHyperdrive.sol";

--- a/contracts/src/instances/morpho-blue/MorphoBlueTarget4.sol
+++ b/contracts/src/instances/morpho-blue/MorphoBlueTarget4.sol
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 pragma solidity 0.8.20;
 
-import { IMorpho } from "morpho-blue/src/interfaces/IMorpho.sol";
 import { HyperdriveTarget4 } from "../../external/HyperdriveTarget4.sol";
 import { IHyperdrive } from "../../interfaces/IHyperdrive.sol";
 import { IMorphoBlueHyperdrive } from "../../interfaces/IMorphoBlueHyperdrive.sol";

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
     "prettier-plugin-multiline-arrays": "^3.0.4",
     "prettier-plugin-organize-imports": "^3.2.4",
     "prettier-plugin-solidity": "^1.3.1",
-    "solhint": "^4.5.2",
+    "solhint": "^5.0.3",
     "solhint-plugin-prettier": "^0.1.0",
     "solidity-coverage": "^0.8.1",
     "ts-node": "^10.9.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5039,10 +5039,10 @@ solhint-plugin-prettier@^0.1.0:
     "@prettier/sync" "^0.3.0"
     prettier-linter-helpers "^1.0.0"
 
-solhint@^4.5.2:
-  version "4.5.2"
-  resolved "https://registry.yarnpkg.com/solhint/-/solhint-4.5.2.tgz#a3fa101366dd1fb37009d24a9f16c99a4a745b5d"
-  integrity sha512-o7MNYS5QPgE6l+PTGOTAUtCzo0ZLnffQsv586hntSHBe2JbSDfkoxfhAOcjZjN4OesTgaX4UEEjCjH9y/4BP5w==
+solhint@^5.0.3:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/solhint/-/solhint-5.0.3.tgz#b57f6d2534fe09a60f9db1b92e834363edd1cbde"
+  integrity sha512-OLCH6qm/mZTCpplTXzXTJGId1zrtNuDYP5c2e6snIv/hdRVxPfBBz/bAlL91bY/Accavkayp2Zp2BaDSrLVXTQ==
   dependencies:
     "@solidity-parser/parser" "^0.18.0"
     ajv "^6.12.6"


### PR DESCRIPTION
# Description

In addition to adding the linter rule, I updated the linter and fixed some new failures. I also investigated the new rule `import-order`, but it's unfortunately not ready for prime-time. I also investigated `forge fmt`, but the formatted output had some pathological edge-cases that made it untenable.