### PR TITLE
Updated `MorphoBlueHyperdrive` to ignore all extra data

### DIFF
--- a/contracts/src/instances/morpho-blue/MorphoBlueBase.sol
+++ b/contracts/src/instances/morpho-blue/MorphoBlueBase.sol
@@ -65,14 +65,12 @@ abstract contract MorphoBlueBase is HyperdriveBase {
 
     /// @dev Accepts a deposit from the user in base.
     /// @param _baseAmount The base amount to deposit.
-    /// @param _extraData Additional data to pass to the Morpho vault. This
-    ///        should be zero if it is unused.
     /// @return sharesMinted The shares that were minted in the deposit.
     /// @return value The amount of ETH to refund. Since this yield source isn't
     ///         payable, this is always zero.
     function _depositWithBase(
         uint256 _baseAmount,
-        bytes calldata _extraData
+        bytes calldata // unused _extraData
     ) internal override returns (uint256 sharesMinted, uint256 value) {
         // Take custody of the deposit in base.
         ERC20(address(_baseToken)).safeTransferFrom(
@@ -90,12 +88,6 @@ abstract contract MorphoBlueBase is HyperdriveBase {
             address(_vault),
             _baseAmount + 1
         );
-        // NOTE: The last 32 bytes of the extra data is passed through to the
-        // event without being passed to morpho.
-        bytes memory data;
-        if (_extraData.length > 32) {
-            data = _extraData[:_extraData.length - 32];
-        }
         (, sharesMinted) = _vault.supply(
             MarketParams({
                 loanToken: address(_baseToken),
@@ -107,7 +99,7 @@ abstract contract MorphoBlueBase is HyperdriveBase {
             _baseAmount,
             0,
             address(this),
-            data
+            new bytes(0)
         );
 
         // NOTE: Since this yield source isn't payable, the value must be zero.

--- a/contracts/src/instances/morpho-blue/MorphoBlueBase.sol
+++ b/contracts/src/instances/morpho-blue/MorphoBlueBase.sol
@@ -90,6 +90,12 @@ abstract contract MorphoBlueBase is HyperdriveBase {
             address(_vault),
             _baseAmount + 1
         );
+        // NOTE: The last 32 bytes of the extra data is passed through to the
+        // event without being passed to morpho.
+        bytes memory data;
+        if (_extraData.length > 32) {
+            data = _extraData[:_extraData.length - 32];
+        }
         (, sharesMinted) = _vault.supply(
             MarketParams({
                 loanToken: address(_baseToken),
@@ -101,7 +107,7 @@ abstract contract MorphoBlueBase is HyperdriveBase {
             _baseAmount,
             0,
             address(this),
-            _extraData
+            data
         );
 
         // NOTE: Since this yield source isn't payable, the value must be zero.

--- a/contracts/src/interfaces/IHyperdrive.sol
+++ b/contracts/src/interfaces/IHyperdrive.sol
@@ -194,7 +194,9 @@ interface IHyperdrive is
         ///      settled in base if true and in the yield source shares if false.
         bool asBase;
         /// @dev Additional data that can be used to implement custom logic in
-        ///      implementation contracts.
+        ///      implementation contracts. By convention, the last 32 bytes of
+        ///      extra data are ignored by instances and "passed through" to the
+        ///      event. This can be used to pass metadata through transactions.
         bytes extraData;
     }
 

--- a/contracts/src/libraries/Constants.sol
+++ b/contracts/src/libraries/Constants.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.20;
 address constant ETH = 0xEeeeeEeeeEeEeeEeEeEeeEEEeeeeEeeeeeeeEEeE;
 
 /// @dev The version of the contracts.
-string constant VERSION = "v1.0.16";
+string constant VERSION = "v1.0.17";
 
 /// @dev The number of targets that must be deployed for a full deployment.
 uint256 constant NUM_TARGETS = 5;


### PR DESCRIPTION
# Description

This PR removes any handling of extra data in Morpho.