### PR TITLE
extract hyperdrivetypes build workflow & use it in two different conditions

### DIFF
--- a/.github/workflows/build_hyperdrivetypes.yml
+++ b/.github/workflows/build_hyperdrivetypes.yml
@@ -1,9 +1,7 @@
 name: build and upload hyperdrivetypes wheel
 
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_call:
 
 jobs:
   build-wheel:

--- a/.github/workflows/build_types_on_change.yml
+++ b/.github/workflows/build_types_on_change.yml
@@ -1,0 +1,15 @@
+name: build and upload hyperdrivetypes wheel on a tag
+
+on:
+  push:
+
+jobs:
+  detect-changes:
+    uses: ./.github/workflows/check_diff.yaml
+    with:
+      pattern: ^python/hyperdrivetypes/pyproject.toml$
+
+  build-wheel:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.changed == 'true'
+    uses: ./.github/workflows/build_hyperdrivetypes.yml

--- a/.github/workflows/build_types_on_change.yml
+++ b/.github/workflows/build_types_on_change.yml
@@ -2,6 +2,8 @@ name: build and upload hyperdrivetypes wheel on a tag
 
 on:
   push:
+    branches:
+      - "main"
 
 jobs:
   detect-changes:

--- a/.github/workflows/build_types_on_tag.yml
+++ b/.github/workflows/build_types_on_tag.yml
@@ -1,0 +1,10 @@
+name: build and upload hyperdrivetypes wheel on a tag
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-wheel:
+    uses: ./.github/workflows/build_hyperdrivetypes.yml

--- a/python/hyperdrivetypes/prerequisite.txt
+++ b/python/hyperdrivetypes/prerequisite.txt
@@ -1,1 +1,1 @@
-pypechain >= 0.0.37
+pypechain == 0.0.37

--- a/python/hyperdrivetypes/pyproject.toml
+++ b/python/hyperdrivetypes/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Natural Language :: English",
 ]
 
-dependencies = ["pypechain>=0.0.37", "fixedpointmath"]
+dependencies = ["pypechain==0.0.37", "fixedpointmath"]
 
 [project.optional-dependencies]
 dev = ["pyright", "pytest"]


### PR DESCRIPTION
This PR changes the `build_hyperdrivetypes.yml` file to be a [reusable workflow](https://docs.github.com/en/actions/sharing-automations/reusing-workflows). We then have two separate actionable workflows that build & ship types if either 1) the hyperdrive version has incremented OR 2) the pyproject.toml version has incremented.

Both of these cases include checks that the first three hyperdrive symver digits (vX.Y.Z) match the first three hyperdrivetypes digits.