### PR TITLE
snARS Integration

### DIFF
--- a/contracts/src/instances/erc4626/ERC4626Base.sol
+++ b/contracts/src/instances/erc4626/ERC4626Base.sol
@@ -79,6 +79,9 @@ abstract contract ERC4626Base is HyperdriveBase {
         address _destination,
         bytes calldata // unused
     ) internal override returns (uint256 amountWithdrawn) {
+        // Get the destination's base balance before the withdrawal.
+        uint256 baseBalanceBefore = _vaultSharesToken.balanceOf(_destination);
+
         // Redeem from the yield source and transfer the
         // resulting base to the destination address.
         amountWithdrawn = IERC4626(address(_vaultSharesToken)).redeem(
@@ -86,6 +89,14 @@ abstract contract ERC4626Base is HyperdriveBase {
             _destination,
             address(this)
         );
+
+        // Ensure that the base was actually received by the destination address.
+        if (
+            _vaultSharesToken.balanceOf(_destination) !=
+            baseBalanceBefore + amountWithdrawn
+        ) {
+            revert IHyperdrive.UnsupportedToken();
+        }
 
         return amountWithdrawn;
     }

--- a/deployments.json
+++ b/deployments.json
@@ -1453,41 +1453,6 @@
             "address": "0xFcdaF9A4A731C24ed2E1BFd6FA918d9CF7F50137",
             "timestamp": "2024-09-23T17:24:41.079Z"
         },
-        "ElementDAO ERC4626 Hyperdrive Deployer Coordinator_ERC4626HyperdriveCoreDeployer": {
-            "contract": "ERC4626HyperdriveCoreDeployer",
-            "address": "0xb1c456824cb526a0b57f6cea309785752ec015d7",
-            "timestamp": "2024-10-09T20:36:51.355Z"
-        },
-        "ElementDAO ERC4626 Hyperdrive Deployer Coordinator_ERC4626Target0Deployer": {
-            "contract": "ERC4626Target0Deployer",
-            "address": "0xd171c68eaa3fbd25c1fa34c1a5e63e193df39aa6",
-            "timestamp": "2024-10-09T20:36:58.302Z"
-        },
-        "ElementDAO ERC4626 Hyperdrive Deployer Coordinator_ERC4626Target1Deployer": {
-            "contract": "ERC4626Target1Deployer",
-            "address": "0xcc2282bf8002701fd31e56d3f6b2c744493ee27f",
-            "timestamp": "2024-10-09T20:37:03.173Z"
-        },
-        "ElementDAO ERC4626 Hyperdrive Deployer Coordinator_ERC4626Target2Deployer": {
-            "contract": "ERC4626Target2Deployer",
-            "address": "0xd917235d89a58af93302e9a998d62735740c8117",
-            "timestamp": "2024-10-09T20:37:06.975Z"
-        },
-        "ElementDAO ERC4626 Hyperdrive Deployer Coordinator_ERC4626Target3Deployer": {
-            "contract": "ERC4626Target3Deployer",
-            "address": "0x77644b188a5d1d58246a233761273c74b0f9d88d",
-            "timestamp": "2024-10-09T20:37:10.677Z"
-        },
-        "ElementDAO ERC4626 Hyperdrive Deployer Coordinator_ERC4626Target4Deployer": {
-            "contract": "ERC4626Target4Deployer",
-            "address": "0xbaa863b62c69993143b013fe7b8af278fd52f76b",
-            "timestamp": "2024-10-09T20:37:15.186Z"
-        },
-        "ElementDAO ERC4626 Hyperdrive Deployer Coordinator": {
-            "contract": "ERC4626HyperdriveDeployerCoordinator",
-            "address": "0x68ba944d89d7481f3a9d73dcb75b7e6c7db5562b",
-            "timestamp": "2024-10-09T20:37:24.510Z"
-        },
         "ElementDAO Moonwell StkWell Hyperdrive Deployer Coordinator_StkWellHyperdriveCoreDeployer": {
             "contract": "StkWellHyperdriveCoreDeployer",
             "address": "0x8d6d5d48f881bcccd6c09256724692b3a971b87b",

--- a/hardhat.config.base.ts
+++ b/hardhat.config.base.ts
@@ -13,7 +13,7 @@ import {
     BASE_FACTORY,
     BASE_MOONWELL_ETH_182DAY,
     BASE_MORPHO_BLUE_COORDINATOR,
-    BASE_SNARS_182DAY,
+    BASE_SNARS_30DAY,
     BASE_STK_WELL_182DAY,
     BASE_STK_WELL_COORDINATOR,
 } from "./tasks/deploy/config/base";
@@ -41,7 +41,7 @@ const config: HardhatUserConfig = {
                     BASE_MORPHO_BLUE_CBETH_USDC_182DAY,
                     BASE_MOONWELL_ETH_182DAY,
                     BASE_STK_WELL_182DAY,
-                    BASE_SNARS_182DAY,
+                    BASE_SNARS_30DAY,
                 ],
                 checkpointRewarders: [],
                 checkpointSubrewarders: [],

--- a/hardhat.config.base.ts
+++ b/hardhat.config.base.ts
@@ -13,6 +13,7 @@ import {
     BASE_FACTORY,
     BASE_MOONWELL_ETH_182DAY,
     BASE_MORPHO_BLUE_COORDINATOR,
+    BASE_SNARS_182DAY,
     BASE_STK_WELL_182DAY,
     BASE_STK_WELL_COORDINATOR,
 } from "./tasks/deploy/config/base";
@@ -40,6 +41,7 @@ const config: HardhatUserConfig = {
                     BASE_MORPHO_BLUE_CBETH_USDC_182DAY,
                     BASE_MOONWELL_ETH_182DAY,
                     BASE_STK_WELL_182DAY,
+                    BASE_SNARS_182DAY,
                 ],
                 checkpointRewarders: [],
                 checkpointSubrewarders: [],

--- a/tasks/deploy/config/base/index.ts
+++ b/tasks/deploy/config/base/index.ts
@@ -4,6 +4,6 @@ export * from "./erc4626-coordinator";
 export * from "./factory";
 export * from "./moonwell-eth-182day";
 export * from "./morpho-blue-coordinator";
-export * from "./snars-182day";
+export * from "./snars-30day";
 export * from "./stk-well-182day";
 export * from "./stk-well-coordinator";

--- a/tasks/deploy/config/base/index.ts
+++ b/tasks/deploy/config/base/index.ts
@@ -4,5 +4,6 @@ export * from "./erc4626-coordinator";
 export * from "./factory";
 export * from "./moonwell-eth-182day";
 export * from "./morpho-blue-coordinator";
+export * from "./snars-182day";
 export * from "./stk-well-182day";
 export * from "./stk-well-coordinator";

--- a/tasks/deploy/config/base/snars-182day.ts
+++ b/tasks/deploy/config/base/snars-182day.ts
@@ -1,0 +1,87 @@
+import { Address, keccak256, parseEther, toBytes } from "viem";
+import {
+    HyperdriveInstanceConfig,
+    getLinkerDetails,
+    normalizeFee,
+    parseDuration,
+    toBytes32,
+} from "../../lib";
+import {
+    NARS_ADDRESS_BASE,
+    SIX_MONTHS,
+    SNARS_ADDRESS_BASE,
+} from "../../lib/constants";
+import { BASE_ERC4626_COORDINATOR_NAME } from "./erc4626-coordinator";
+import { BASE_FACTORY_NAME } from "./factory";
+
+// The name of the pool.
+export const BASE_SNARS_182DAY_NAME =
+    "ElementDAO 182 Day Num Finance snARS Hyperdrive";
+
+// The initial contribution of the pool.
+const CONTRIBUTION = parseEther("100");
+
+export const BASE_SNARS_182DAY: HyperdriveInstanceConfig<"ERC4626"> = {
+    name: BASE_SNARS_182DAY_NAME,
+    prefix: "ERC4626",
+    coordinatorAddress: async (hre) =>
+        hre.hyperdriveDeploy.deployments.byName(BASE_ERC4626_COORDINATOR_NAME)
+            .address,
+    deploymentId: keccak256(toBytes(BASE_SNARS_182DAY_NAME)),
+    salt: toBytes32("0x69420"),
+    extraData: "0x",
+    contribution: CONTRIBUTION,
+    fixedAPR: parseEther("0.1"),
+    timestretchAPR: parseEther("0.1"),
+    options: async (hre) => ({
+        extraData: "0x",
+        asBase: true,
+        destination: (await hre.getNamedAccounts())["deployer"] as Address,
+    }),
+    // Prepare to deploy the contract by setting approvals.
+    prepare: async (hre) => {
+        let baseToken = await hre.viem.getContractAt(
+            "contracts/src/interfaces/IERC20.sol:IERC20",
+            NARS_ADDRESS_BASE,
+        );
+        let tx = await baseToken.write.approve([
+            hre.hyperdriveDeploy.deployments.byName(
+                BASE_ERC4626_COORDINATOR_NAME,
+            ).address,
+            CONTRIBUTION,
+        ]);
+        let pc = await hre.viem.getPublicClient();
+        await pc.waitForTransactionReceipt({ hash: tx });
+    },
+    poolDeployConfig: async (hre) => {
+        let factoryContract = await hre.viem.getContractAt(
+            "HyperdriveFactory",
+            hre.hyperdriveDeploy.deployments.byName(BASE_FACTORY_NAME).address,
+        );
+        return {
+            baseToken: NARS_ADDRESS_BASE,
+            vaultSharesToken: SNARS_ADDRESS_BASE,
+            circuitBreakerDelta: parseEther("0.075"),
+            minimumShareReserves: parseEther("0.001"),
+            minimumTransactionAmount: parseEther("0.001"),
+            positionDuration: parseDuration(SIX_MONTHS),
+            checkpointDuration: parseDuration("1 day"),
+            timeStretch: 0n,
+            governance: await factoryContract.read.governance(),
+            feeCollector: await factoryContract.read.feeCollector(),
+            sweepCollector: await factoryContract.read.sweepCollector(),
+            checkpointRewarder: await factoryContract.read.checkpointRewarder(),
+            ...(await getLinkerDetails(
+                hre,
+                hre.hyperdriveDeploy.deployments.byName(BASE_FACTORY_NAME)
+                    .address,
+            )),
+            fees: {
+                curve: parseEther("0.01"),
+                flat: normalizeFee(parseEther("0.0005"), SIX_MONTHS),
+                governanceLP: parseEther("0.15"),
+                governanceZombie: parseEther("0.03"),
+            },
+        };
+    },
+};

--- a/tasks/deploy/config/base/snars-30day.ts
+++ b/tasks/deploy/config/base/snars-30day.ts
@@ -8,26 +8,26 @@ import {
 } from "../../lib";
 import {
     NARS_ADDRESS_BASE,
-    SIX_MONTHS,
+    ONE_MONTH,
     SNARS_ADDRESS_BASE,
 } from "../../lib/constants";
 import { BASE_ERC4626_COORDINATOR_NAME } from "./erc4626-coordinator";
 import { BASE_FACTORY_NAME } from "./factory";
 
 // The name of the pool.
-export const BASE_SNARS_182DAY_NAME =
-    "ElementDAO 182 Day Num Finance snARS Hyperdrive";
+export const BASE_SNARS_30DAY_NAME =
+    "ElementDAO 30 Day Num Finance snARS Hyperdrive";
 
 // The initial contribution of the pool.
 const CONTRIBUTION = parseEther("100");
 
-export const BASE_SNARS_182DAY: HyperdriveInstanceConfig<"ERC4626"> = {
-    name: BASE_SNARS_182DAY_NAME,
+export const BASE_SNARS_30DAY: HyperdriveInstanceConfig<"ERC4626"> = {
+    name: BASE_SNARS_30DAY_NAME,
     prefix: "ERC4626",
     coordinatorAddress: async (hre) =>
         hre.hyperdriveDeploy.deployments.byName(BASE_ERC4626_COORDINATOR_NAME)
             .address,
-    deploymentId: keccak256(toBytes(BASE_SNARS_182DAY_NAME)),
+    deploymentId: keccak256(toBytes(BASE_SNARS_30DAY_NAME)),
     salt: toBytes32("0x69420"),
     extraData: "0x",
     contribution: CONTRIBUTION,
@@ -64,7 +64,7 @@ export const BASE_SNARS_182DAY: HyperdriveInstanceConfig<"ERC4626"> = {
             circuitBreakerDelta: parseEther("0.075"),
             minimumShareReserves: parseEther("0.001"),
             minimumTransactionAmount: parseEther("0.001"),
-            positionDuration: parseDuration(SIX_MONTHS),
+            positionDuration: parseDuration(ONE_MONTH),
             checkpointDuration: parseDuration("1 day"),
             timeStretch: 0n,
             governance: await factoryContract.read.governance(),
@@ -78,7 +78,7 @@ export const BASE_SNARS_182DAY: HyperdriveInstanceConfig<"ERC4626"> = {
             )),
             fees: {
                 curve: parseEther("0.01"),
-                flat: normalizeFee(parseEther("0.0005"), SIX_MONTHS),
+                flat: normalizeFee(parseEther("0.0005"), ONE_MONTH),
                 governanceLP: parseEther("0.15"),
                 governanceZombie: parseEther("0.03"),
             },

--- a/tasks/deploy/lib/constants.ts
+++ b/tasks/deploy/lib/constants.ts
@@ -161,6 +161,15 @@ export const CHAINLINK_AGGREGATOR_CBETH_ETH_PROXY_BASE =
 export const MOONWELL_ETH_ADDRESS_BASE =
     "0xa0E430870c4604CcfC7B38Ca7845B1FF653D0ff1" as Address;
 
+export const NARS_ADDRESS_BASE =
+    "0x5e40f26E89213660514c51Fb61b2d357DBf63C85" as Address;
+
+export const SNARS_ADDRESS_BASE =
+    "0xC1F4C75e8925A67BE4F35D6b1c044B5ea8849a58" as Address;
+
+export const STK_WELL_ADDRESS_BASE =
+    "0xe66E3A37C3274Ac24FE8590f7D84A2427194DC17" as Address;
+
 export const USDC_ADDRESS_BASE =
     "0x833589fCD6eDb6E08f4c7C32D4f71b54bdA02913" as Address;
 
@@ -169,9 +178,6 @@ export const WETH_ADDRESS_BASE =
 
 export const WELL_ADDRESS_BASE =
     "0xA88594D404727625A9437C3f886C7643872296AE" as Address;
-
-export const STK_WELL_ADDRESS_BASE =
-    "0xe66E3A37C3274Ac24FE8590f7D84A2427194DC17" as Address;
 
 // ╭─────────────────────────────────────────────────────────╮
 // │ Base Whales                                             │

--- a/tasks/deploy/lib/constants.ts
+++ b/tasks/deploy/lib/constants.ts
@@ -216,6 +216,8 @@ export const WSTETH_WHALE_GNOSIS =
 // │ Durations                                               │
 // ╰─────────────────────────────────────────────────────────╯
 
+export const ONE_MONTH = "30 days";
+
 export const THREE_MONTHS = "91 days";
 
 export const SIX_MONTHS = "182 days";

--- a/test/instances/erc4626/ERC4626HyperdriveInstanceTest.t.sol
+++ b/test/instances/erc4626/ERC4626HyperdriveInstanceTest.t.sol
@@ -83,7 +83,13 @@ abstract contract ERC4626HyperdriveInstanceTest is InstanceTest {
     /// @dev Fetches the total supply of the base and share tokens.
     /// @return The total supply of base.
     /// @return The total supply of vault shares.
-    function getSupply() internal view override returns (uint256, uint256) {
+    function getSupply()
+        internal
+        view
+        virtual
+        override
+        returns (uint256, uint256)
+    {
         return (
             IERC4626(address(config.vaultSharesToken)).totalAssets(),
             IERC4626(address(config.vaultSharesToken)).totalSupply()
@@ -122,7 +128,7 @@ abstract contract ERC4626HyperdriveInstanceTest is InstanceTest {
         // Ensure that the share price is the expected value.
         (uint256 totalBase, uint256 totalSupply) = getSupply();
         uint256 vaultSharePrice = hyperdrive.getPoolInfo().vaultSharePrice;
-        assertEq(vaultSharePrice, totalBase.divDown(totalSupply));
+        assertApproxEqAbs(vaultSharePrice, totalBase.divDown(totalSupply), 1);
 
         // Ensure that the share price accurately predicts the amount of shares
         // that will be minted for depositing a given amount of shares. This will

--- a/test/instances/erc4626/SnARS.t.sol
+++ b/test/instances/erc4626/SnARS.t.sol
@@ -67,31 +67,31 @@ contract SnARSHyperdriveTest is ERC4626HyperdriveInstanceTest {
                 }),
                 enableBaseDeposits: true,
                 enableShareDeposits: true,
-                enableBaseWithdraws: true,
+                enableBaseWithdraws: false,
                 enableShareWithdraws: true,
-                baseWithdrawError: new bytes(0),
+                baseWithdrawError: abi.encodeWithSelector(
+                    IHyperdrive.UnsupportedToken.selector
+                ),
                 isRebasing: false,
                 shouldAccrueInterest: true,
-                // FIXME
+                // NOTE: Base  withdrawals are disabled, so the tolerances are zero.
                 //
                 // The base test tolerances.
-                closeLongWithBaseTolerance: 20,
-                roundTripLpInstantaneousWithBaseTolerance: 1e5,
-                roundTripLpWithdrawalSharesWithBaseTolerance: 1e6,
-                roundTripLongInstantaneousWithBaseUpperBoundTolerance: 1e3,
-                roundTripLongInstantaneousWithBaseTolerance: 1e5,
-                roundTripLongMaturityWithBaseUpperBoundTolerance: 1e3,
-                roundTripLongMaturityWithBaseTolerance: 1e5,
-                roundTripShortInstantaneousWithBaseUpperBoundTolerance: 1e3,
-                roundTripShortInstantaneousWithBaseTolerance: 1e5,
-                roundTripShortMaturityWithBaseTolerance: 1e5,
-                // FIXME
-                //
+                closeLongWithBaseTolerance: 0,
+                roundTripLpInstantaneousWithBaseTolerance: 0,
+                roundTripLpWithdrawalSharesWithBaseTolerance: 0,
+                roundTripLongInstantaneousWithBaseUpperBoundTolerance: 0,
+                roundTripLongInstantaneousWithBaseTolerance: 0,
+                roundTripLongMaturityWithBaseUpperBoundTolerance: 0,
+                roundTripLongMaturityWithBaseTolerance: 0,
+                roundTripShortInstantaneousWithBaseUpperBoundTolerance: 0,
+                roundTripShortInstantaneousWithBaseTolerance: 0,
+                roundTripShortMaturityWithBaseTolerance: 0,
                 // The share test tolerances.
                 closeLongWithSharesTolerance: 20,
                 closeShortWithSharesTolerance: 100,
                 roundTripLpInstantaneousWithSharesTolerance: 1e7,
-                roundTripLpWithdrawalSharesWithSharesTolerance: 1e7,
+                roundTripLpWithdrawalSharesWithSharesTolerance: 1e8,
                 roundTripLongInstantaneousWithSharesUpperBoundTolerance: 1e3,
                 roundTripLongInstantaneousWithSharesTolerance: 1e5,
                 roundTripLongMaturityWithSharesUpperBoundTolerance: 1e3,
@@ -99,8 +99,6 @@ contract SnARSHyperdriveTest is ERC4626HyperdriveInstanceTest {
                 roundTripShortInstantaneousWithSharesUpperBoundTolerance: 1e3,
                 roundTripShortInstantaneousWithSharesTolerance: 1e5,
                 roundTripShortMaturityWithSharesTolerance: 1e5,
-                // FIXME
-                //
                 // The verification tolerances.
                 verifyDepositTolerance: 2,
                 verifyWithdrawalTolerance: 2
@@ -112,6 +110,22 @@ contract SnARSHyperdriveTest is ERC4626HyperdriveInstanceTest {
     function setUp() public override __base_fork(21_071_334) {
         // Invoke the Instance testing suite setup.
         super.setUp();
+    }
+
+    /// @dev HACK: The snARS vault returns a total assets of 0, so we have to
+    ///      override this.
+    /// @dev Fetches the total supply of the base and share tokens.
+    /// @return The total supply of base.
+    /// @return The total supply of vault shares.
+    function getSupply() internal view override returns (uint256, uint256) {
+        uint256 totalShares = IERC4626(address(config.vaultSharesToken))
+            .totalSupply();
+        return (
+            IERC4626(address(config.vaultSharesToken)).convertToAssets(
+                totalShares
+            ),
+            totalShares
+        );
     }
 
     /// Helpers ///

--- a/test/instances/erc4626/SnARS.t.sol
+++ b/test/instances/erc4626/SnARS.t.sol
@@ -1,0 +1,140 @@
+// SPDX-License-Identifier: Apache-2.0
+pragma solidity 0.8.22;
+
+import { stdStorage, StdStorage } from "forge-std/Test.sol";
+import { IERC20 } from "../../../contracts/src/interfaces/IERC20.sol";
+import { IERC4626 } from "../../../contracts/src/interfaces/IERC4626.sol";
+import { IHyperdrive } from "../../../contracts/src/interfaces/IHyperdrive.sol";
+import { HyperdriveUtils } from "../../utils/HyperdriveUtils.sol";
+import { InstanceTest } from "../../utils/InstanceTest.sol";
+import { Lib } from "../../utils/Lib.sol";
+import { ERC4626HyperdriveInstanceTest } from "./ERC4626HyperdriveInstanceTest.t.sol";
+
+interface ISnARS is IERC20 {
+    function numStakingContract() external view returns (IStaking);
+}
+
+interface IStaking {
+    function setApy(uint256) external;
+}
+
+contract SnARSHyperdriveTest is ERC4626HyperdriveInstanceTest {
+    using HyperdriveUtils for uint256;
+    using HyperdriveUtils for IHyperdrive;
+    using Lib for *;
+    using stdStorage for StdStorage;
+
+    /// @dev The admin that can update the snARS APY.
+    address internal constant SNARS_ADMIN =
+        0x062F9f2e46cDEF536D0E10c6cb31f951921c4A68;
+
+    /// @dev The nARS contract.
+    IERC20 internal constant NARS =
+        IERC20(0x5e40f26E89213660514c51Fb61b2d357DBf63C85);
+
+    /// @dev The snARS contract.
+    ISnARS internal constant SNARS =
+        ISnARS(0xC1F4C75e8925A67BE4F35D6b1c044B5ea8849a58);
+
+    /// @dev Whale accounts.
+    address internal NARS_TOKEN_WHALE =
+        address(0x1ebc5e10D58e1d78A28971B5776Ea6A64CB88329);
+    address[] internal baseTokenWhaleAccounts = [NARS_TOKEN_WHALE];
+    address internal SNARS_TOKEN_WHALE =
+        address(0x54423d0A5c4e3a6Eb8Bd12FDD54c1e6b42D52Ebe);
+    address[] internal vaultSharesTokenWhaleAccounts = [SNARS_TOKEN_WHALE];
+
+    /// @notice Instantiates the instance testing suite with the configuration.
+    constructor()
+        InstanceTest(
+            InstanceTestConfig({
+                name: "Hyperdrive",
+                kind: "ERC4626Hyperdrive",
+                decimals: 18,
+                baseTokenWhaleAccounts: baseTokenWhaleAccounts,
+                vaultSharesTokenWhaleAccounts: vaultSharesTokenWhaleAccounts,
+                baseToken: NARS,
+                vaultSharesToken: SNARS,
+                shareTolerance: 1e3,
+                minimumShareReserves: 1e15,
+                minimumTransactionAmount: 1e15,
+                positionDuration: POSITION_DURATION,
+                fees: IHyperdrive.Fees({
+                    curve: 0,
+                    flat: 0,
+                    governanceLP: 0,
+                    governanceZombie: 0
+                }),
+                enableBaseDeposits: true,
+                enableShareDeposits: true,
+                enableBaseWithdraws: true,
+                enableShareWithdraws: true,
+                baseWithdrawError: new bytes(0),
+                isRebasing: false,
+                shouldAccrueInterest: true,
+                // FIXME
+                //
+                // The base test tolerances.
+                closeLongWithBaseTolerance: 20,
+                roundTripLpInstantaneousWithBaseTolerance: 1e5,
+                roundTripLpWithdrawalSharesWithBaseTolerance: 1e6,
+                roundTripLongInstantaneousWithBaseUpperBoundTolerance: 1e3,
+                roundTripLongInstantaneousWithBaseTolerance: 1e5,
+                roundTripLongMaturityWithBaseUpperBoundTolerance: 1e3,
+                roundTripLongMaturityWithBaseTolerance: 1e5,
+                roundTripShortInstantaneousWithBaseUpperBoundTolerance: 1e3,
+                roundTripShortInstantaneousWithBaseTolerance: 1e5,
+                roundTripShortMaturityWithBaseTolerance: 1e5,
+                // FIXME
+                //
+                // The share test tolerances.
+                closeLongWithSharesTolerance: 20,
+                closeShortWithSharesTolerance: 100,
+                roundTripLpInstantaneousWithSharesTolerance: 1e7,
+                roundTripLpWithdrawalSharesWithSharesTolerance: 1e7,
+                roundTripLongInstantaneousWithSharesUpperBoundTolerance: 1e3,
+                roundTripLongInstantaneousWithSharesTolerance: 1e5,
+                roundTripLongMaturityWithSharesUpperBoundTolerance: 1e3,
+                roundTripLongMaturityWithSharesTolerance: 1e5,
+                roundTripShortInstantaneousWithSharesUpperBoundTolerance: 1e3,
+                roundTripShortInstantaneousWithSharesTolerance: 1e5,
+                roundTripShortMaturityWithSharesTolerance: 1e5,
+                // FIXME
+                //
+                // The verification tolerances.
+                verifyDepositTolerance: 2,
+                verifyWithdrawalTolerance: 2
+            })
+        )
+    {}
+
+    /// @notice Forge function that is invoked to setup the testing environment.
+    function setUp() public override __base_fork(21_071_334) {
+        // Invoke the Instance testing suite setup.
+        super.setUp();
+    }
+
+    /// Helpers ///
+
+    /// @dev Advance time and accrue interest.
+    /// @param timeDelta The time to advance.
+    /// @param variableRate The variable rate.
+    function advanceTime(
+        uint256 timeDelta,
+        int256 variableRate
+    ) internal override {
+        // Ensure the variable rate isn't negative.
+        require(variableRate >= 0, "SnARSHyperdriveTest: negative rate");
+
+        // Update the APY of the staking contract.
+        vm.stopPrank();
+        vm.startPrank(SNARS_ADMIN);
+        IStaking staking = SNARS.numStakingContract();
+        // NOTE: Since we aren't calling this contract repeatedly, this
+        // functions as an APR.
+        staking.setApy(uint256(variableRate));
+
+        // Advance the time.
+        vm.warp(block.timestamp + timeDelta);
+    }
+}


### PR DESCRIPTION
# Description

This PR adds the snARS integration. This yield source is a staking vault for the nARS stable coin. Some interesting things about this yield source are that `asBase = true` is not supported on withdrawal since the user will not receive adequate base (nARS is instead locked in an escrow contract, which we don't want to subject our users to). 