### PR TITLE
Fixes for duplicate references to struct by bumping pypechain version. Includes version bump to v1.0.20.9

### DIFF
--- a/python/hyperdrivetypes/prerequisite.txt
+++ b/python/hyperdrivetypes/prerequisite.txt
@@ -1,1 +1,1 @@
-pypechain == 0.0.45
+pypechain == 0.0.46

--- a/python/hyperdrivetypes/pyproject.toml
+++ b/python/hyperdrivetypes/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hyperdrivetypes"
-version = "1.0.20.8"
+version = "1.0.20.9"
 
 # Authors are the current, primary stewards of the repo
 # contributors can be found on github
@@ -19,7 +19,7 @@ classifiers = [
     "Natural Language :: English",
 ]
 
-dependencies = ["pypechain==0.0.45", "fixedpointmath"]
+dependencies = ["pypechain==0.0.46", "fixedpointmath"]
 
 [project.optional-dependencies]
 dev = ["pyright>=1.1.384", "pytest"]


### PR DESCRIPTION
See https://github.com/delvtech/pypechain/pull/146 for fix