### PR TITLE
Fixed the issue with open short

### DIFF
--- a/contracts/src/internal/HyperdriveShort.sol
+++ b/contracts/src/internal/HyperdriveShort.sol
@@ -99,6 +99,11 @@ abstract contract HyperdriveShort is IHyperdriveEvents, HyperdriveLP {
                 block.timestamp,
                 spotPrice
             );
+
+            // Adjust the base deposit to ensure that we are overestimating the
+            // amount of base that needs to be deposited to provide the required
+            // amount of vault shares for the pool to remain solvent.
+            baseDeposit = _convertToBase(baseDeposit.divDown(vaultSharePrice));
         }
 
         // Take custody of the trader's deposit and ensure that the trader

--- a/contracts/src/internal/HyperdriveShort.sol
+++ b/contracts/src/internal/HyperdriveShort.sol
@@ -103,7 +103,13 @@ abstract contract HyperdriveShort is IHyperdriveEvents, HyperdriveLP {
             // Adjust the base deposit to ensure that we are overestimating the
             // amount of base that needs to be deposited to provide the required
             // amount of vault shares for the pool to remain solvent.
-            baseDeposit = _convertToBase(baseDeposit.divDown(vaultSharePrice));
+            //
+            // NOTE: We round up and add 1 wei to the base deposit to ensure
+            // that the deposit in shares is greater than or equal to the amount
+            // required to maintain solvency.
+            baseDeposit =
+                _convertToBase(baseDeposit.divUp(vaultSharePrice)) +
+                1;
         }
 
         // Take custody of the trader's deposit and ensure that the trader

--- a/test/instances/morpho-blue/MorphoBlue_USDe_DAI_Hyperdrive.t.sol
+++ b/test/instances/morpho-blue/MorphoBlue_USDe_DAI_Hyperdrive.t.sol
@@ -69,7 +69,7 @@ contract MorphoBlue_USDe_DAI_HyperdriveTest is
                 roundTripLongMaturityWithBaseUpperBoundTolerance: 1e3,
                 roundTripLongMaturityWithBaseTolerance: 1e5,
                 roundTripShortInstantaneousWithBaseUpperBoundTolerance: 1e3,
-                roundTripShortInstantaneousWithBaseTolerance: 1e5,
+                roundTripShortInstantaneousWithBaseTolerance: 1e7,
                 roundTripShortMaturityWithBaseTolerance: 1e10,
                 // NOTE: Share deposits and withdrawals are disabled, so these are
                 // 0.

--- a/test/instances/morpho-blue/MorphoBlue_sUSDe_DAI_Hyperdrive.t.sol
+++ b/test/instances/morpho-blue/MorphoBlue_sUSDe_DAI_Hyperdrive.t.sol
@@ -69,7 +69,7 @@ contract MorphoBlue_sUSDe_DAI_HyperdriveTest is
                 roundTripLongMaturityWithBaseUpperBoundTolerance: 1e3,
                 roundTripLongMaturityWithBaseTolerance: 1e5,
                 roundTripShortInstantaneousWithBaseUpperBoundTolerance: 1e3,
-                roundTripShortInstantaneousWithBaseTolerance: 1e5,
+                roundTripShortInstantaneousWithBaseTolerance: 1e8,
                 roundTripShortMaturityWithBaseTolerance: 1e10,
                 // NOTE: Share deposits and withdrawals are disabled, so these are
                 // 0.

--- a/test/instances/morpho-blue/MorphoBlue_wstETH_USDA_Hyperdrive.t.sol
+++ b/test/instances/morpho-blue/MorphoBlue_wstETH_USDA_Hyperdrive.t.sol
@@ -69,7 +69,7 @@ contract MorphoBlue_wstETH_USDA_HyperdriveTest is
                 roundTripLongMaturityWithBaseUpperBoundTolerance: 1e3,
                 roundTripLongMaturityWithBaseTolerance: 1e5,
                 roundTripShortInstantaneousWithBaseUpperBoundTolerance: 1e3,
-                roundTripShortInstantaneousWithBaseTolerance: 1e5,
+                roundTripShortInstantaneousWithBaseTolerance: 1e8,
                 roundTripShortMaturityWithBaseTolerance: 1e10,
                 // NOTE: Share deposits and withdrawals are disabled, so these are
                 // 0.

--- a/test/integrations/hyperdrive/NonstandardDecimals.sol
+++ b/test/integrations/hyperdrive/NonstandardDecimals.sol
@@ -54,7 +54,7 @@ contract NonstandardDecimalsTest is HyperdriveTest {
         (, uint256 shortBasePaid) = openShort(celine, bondAmount);
 
         // Ensure that the long and short fixed interest are equal.
-        assertApproxEqAbs(bondAmount - longBasePaid, shortBasePaid, 3);
+        assertApproxEqAbs(bondAmount - longBasePaid, shortBasePaid, 4);
     }
 
     function test_nonstandard_decimals_longs_outstanding() external {

--- a/test/units/hyperdrive/AddLiquidityTest.t.sol
+++ b/test/units/hyperdrive/AddLiquidityTest.t.sol
@@ -392,11 +392,12 @@ contract AddLiquidityTest is HyperdriveTest {
 
         // Ensure that all of the capital except for the minimum share reserves
         // and the zero address's LP present value was removed from the system.
-        assertEq(
+        assertApproxEqAbs(
             baseToken.balanceOf(address(hyperdrive)),
             (ONE + hyperdrive.lpSharePrice()).mulDown(
                 hyperdrive.getPoolConfig().minimumShareReserves
-            )
+            ),
+            1
         );
     }
 
@@ -502,11 +503,12 @@ contract AddLiquidityTest is HyperdriveTest {
 
         // Ensure that all of the capital except for the minimum share reserves
         // and the zero address's LP present value was removed from the system.
-        assertEq(
+        assertApproxEqAbs(
             baseToken.balanceOf(address(hyperdrive)),
             (ONE + hyperdrive.lpSharePrice()).mulDown(
                 hyperdrive.getPoolConfig().minimumShareReserves
-            )
+            ),
+            1
         );
     }
 

--- a/test/units/hyperdrive/OpenShortTest.t.sol
+++ b/test/units/hyperdrive/OpenShortTest.t.sol
@@ -488,10 +488,11 @@ contract OpenShortTest is HyperdriveTest {
         IHyperdrive.PoolInfo memory poolInfoAfter = hyperdrive.getPoolInfo();
 
         {
-            assertEq(
+            assertApproxEqAbs(
                 poolInfoAfter.shareReserves,
                 poolInfoBefore.shareReserves -
-                    baseProceeds.divDown(poolInfoBefore.vaultSharePrice)
+                    baseProceeds.divDown(poolInfoBefore.vaultSharePrice),
+                1
             );
             assertEq(
                 poolInfoAfter.vaultSharePrice,
@@ -573,7 +574,7 @@ contract OpenShortTest is HyperdriveTest {
             hyperdrive.getPoolInfo().vaultSharePrice
         );
         assertEq(eventAsBase, true);
-        assertEq(eventBaseProceeds, shortAmount - basePaid);
+        assertApproxEqAbs(eventBaseProceeds, shortAmount - basePaid, 1);
         assertEq(eventBondAmount, shortAmount);
     }
 }

--- a/test/utils/InstanceTest.sol
+++ b/test/utils/InstanceTest.sol
@@ -2673,6 +2673,20 @@ abstract contract InstanceTest is HyperdriveTest {
         );
         (uint256 maturityTime, uint256 basePaid) = openShort(bob, _shortAmount);
 
+        // Ensure that the pool has more shares than expected. This verifies
+        // that the pool is solvent.
+        assertGe(
+            hyperdrive.totalShares(),
+            hyperdrive.getPoolInfo().shareReserves +
+                (hyperdrive.getPoolInfo().shortsOutstanding +
+                    hyperdrive.getPoolInfo().shortsOutstanding.mulDown(
+                        hyperdrive.getPoolConfig().fees.flat
+                    )).divDown(hyperdrive.getPoolInfo().vaultSharePrice) +
+                hyperdrive.getUncollectedGovernanceFees() +
+                hyperdrive.getPoolInfo().withdrawalSharesProceeds +
+                hyperdrive.getPoolInfo().zombieShareReserves
+        );
+
         // Get some balance information before the withdrawal.
         (
             uint256 totalSupplyAssetsBefore,


### PR DESCRIPTION
# Description

This PR fixes a minor issue with `openShort` that ensures that the amount of shares owned by the pool are always greater than the expected amount. This ensures that the system is always completely solvent. Despite the old pool design making it possible to have small amounts of insolvency, in practice this wasn't an issue because the magnitudes were so small. The following is an analysis of why this wasn't an issue.

## Insolvency Writeup

Sheng surfaced a failing fuzz test that indicates insolvency on the Morpho Blue wstETH/USDA Hyperdrive pool. After investigating this issue, I noticed that this issue will occur whenever shorts are opened because of the imprecision in converting from shares to base using the vault share price. 

Since this pool already has a fairly large amount of liquidity in it ($10k), it would be annoying for all involved to have to redeploy the pool. DELV has already deployed ~$80 of USDA to the pool, so depending on the amount of insolvency, this will be covered by DELV's initial deposit.

### Issue Analysis

To get a better understanding of the insolvency issue surfaced yesterday, it's useful to understand the magnitude of the insolvency. If the insolvency is small enough, it can be covered by the initial liquidity supplied to the pool.

On a short of `156.468005765553258496` bonds, we run into a small amount of insolvency immediately. Looking at the expected balance of vault shares versus the actual balance of vault shares measured in vault shares and base, we can see that the discrepancy is quite small:

```
# Insolvency after shorting 156.46 bonds
expected - actual = 0.000002382523430226 (vault shares)
expected - actual = 0.000000000002426696 (base)
```

If the short amount is increased to the max short of `3231.05668405864919373` bonds, the insolvency amounts are:

```
# Insolvency after shorting 3,231.05 bonds
expected - actual = 0.000124150061041186 (vault shares)
expected - actual = 0.000000000126451877 (base)
```

To get a better sense of what this looks like in an extreme case, we'll add lots of liquidity before opening the max short. When we add `6_000_000` USDA of liquidity and open a max short of `2_011_395.096051101066013435`, the insolvency amounts are:

```
# Insolvency after shorting 2,011,395.09 bonds
expected - actual = 0.073716526583006505 (vault shares)
expected - actual = 0.000000075083275057 (base)
```

Plotting an additional point on this line, we can see that insolvency scales with bonds with a slope of approximately `4e-14` base of insolvency per bond. Using this linear regression model, we can solve for the short volume that will result in an insolvency of $80:

```
80 = 4e-14 * volume 

        => 
        
volume = 80 / 4e-14 = ~1.98 quadrillion bonds of volume
```

To make sure that this analysis isn't leaving anything off, I tried to see what the impact of closing shorts immediately would have on solvency. In the three examples we have the following results:

```
# Insolvency after shorting 156.46 bonds
expected - actual = 0.000000046582281669 (vault shares)
expected - actual = 0.000000000000047445 (base)

# Insolvency after shorting 3,231.05 bonds
expected - actual = 0.000006210721733739 (vault shares)
expected - actual = 0.000000000006325872 (base)

# Insolvency after shorting 2,011,395.09 bonds
expected - actual = 0.003687738504722341 (vault shares)
expected - actual = 0.000000003756111381 (base)
```

Doing the same linear regression on these points, the insolvency per bond that is bought and immediately sold is `~2e-15`. Solving for the amount of this volume that is required to achieve insolvency of $80 we get:

```
80 = 2e-15 * volume 

        => 
        
volume = 80 / 2e-15 = ~40 quadrillion bonds of volume
```

Next, I'll plot similar points if we close the longs at maturity with the variable rate staying constant for the full term. As we can see from the points below, closing at maturity results in the pool becoming more solvent, so we can support an infinite amount of volume in this direction.

```
# Insolvency after shorting 156.46 bonds
expected - actual = -655.548941700312485531    (vault shares)
expected - actual = -0.000679298418179787      (base)

# Insolvency after shorting 3,231.05 bonds
expected - actual = -14182.720602672148916913  (vault shares)
expected - actual = -0.014696361667379226      (base)

# Insolvency after shorting 2,011,395.09 bonds
expected - actual = -392669.718584225548928331 (vault shares)
expected - actual = -0.400268410847870286      (base)
```

### Verdict

Given the extremely small monetary value of the insolvency accrued on the short, the pool can support more volume than we'll ever need it to support. This pool would require more volume than is processed in mature treasury markets in a decade to be more than $80 insolvent, and the pool's solvency is improved when shorts are held to maturity. 