### PR TITLE
Only pin minimum version of pypechain. Bumping hyperdrivetypes version to 1.0.20.13

### DIFF
--- a/python/hyperdrivetypes/prerequisite.txt
+++ b/python/hyperdrivetypes/prerequisite.txt
@@ -1,1 +1,1 @@
-pypechain == 0.0.48
+pypechain >= 0.0.48

--- a/python/hyperdrivetypes/pyproject.toml
+++ b/python/hyperdrivetypes/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "hyperdrivetypes"
-version = "1.0.20.12"
+version = "1.0.20.13"
 
 # Authors are the current, primary stewards of the repo
 # contributors can be found on github
@@ -20,7 +20,7 @@ classifiers = [
     "Natural Language :: English",
 ]
 
-dependencies = ["pypechain==0.0.48", "fixedpointmath"]
+dependencies = ["pypechain>=0.0.48", "fixedpointmath"]
 
 [project.optional-dependencies]
 dev = ["pyright>=1.1.384", "pytest"]


### PR DESCRIPTION
Pinning only minimum version allows Pypechain to upgrade if there's no breaking changes. Bumping hyperdrivetypes version to upload to pypi. This allows more version flexibility downstream.