### PR TITLE
change hyperwasm import from get-rate to dynamic

### DIFF
--- a/tasks/get-rate.ts
+++ b/tasks/get-rate.ts
@@ -5,7 +5,7 @@ import {
     HyperdriveDeployBaseTaskParams,
 } from "./deploy";
 
-import * as hyperwasm from "@delvtech/hyperdrive-wasm";
+// import * as hyperwasm from "@delvtech/hyperdrive-wasm";
 
 export type MarketStateParams = HyperdriveDeployBaseTaskParams & {
     address: string;
@@ -35,6 +35,7 @@ HyperdriveDeployBaseTask(
             { address, amount }: Required<MarketStateParams>,
             { viem, hyperdriveDeploy: { deployments }, network },
         ) => {
+            const hyperwasm = await import("@delvtech/hyperdrive-wasm");
             let instance = await viem.getContractAt(
                 "IHyperdriveRead",
                 address as Address,

--- a/tasks/get-rate.ts
+++ b/tasks/get-rate.ts
@@ -5,8 +5,6 @@ import {
     HyperdriveDeployBaseTaskParams,
 } from "./deploy";
 
-// import * as hyperwasm from "@delvtech/hyperdrive-wasm";
-
 export type MarketStateParams = HyperdriveDeployBaseTaskParams & {
     address: string;
     amount: string;


### PR DESCRIPTION
CI fix: changed hyperdrive-wasm import in `get-rate.ts` task to be a dynamic import, since hyperwasm is an ESM module which created compatibility issues with Commonjs and caused CI to fail.